### PR TITLE
Fix erroneous minetest.settings function calls

### DIFF
--- a/mods/ambience/14init.lua
+++ b/mods/ambience/14init.lua
@@ -5,22 +5,22 @@ local max_frequency_all = 1000 --the larger you make this number the lest freque
 
 --for frequencies below use a number between 0 and max_frequency_all
 --for volumes below, use a number between 0.0 and 1, the larger the number the louder the sounds
-local night_frequency = 20  --owls, wolves 
-local night_volume = 0.9  
+local night_frequency = 20  --owls, wolves
+local night_volume = 0.9
 local night_frequent_frequency = 150  --crickets
 local night_frequent_volume = 0.9
 local day_frequency = 100  --crow, bluejay, cardinal
-local day_volume = 0.9 
+local day_volume = 0.9
 local day_frequent_frequency = 1000  --crow, bluejay, cardinal
 local day_frequent_volume = 0.18
 local cave_frequency = 10  --bats
-local cave_volume = 1.0  
+local cave_volume = 1.0
 local cave_frequent_frequency = 70  --drops of water dripping
-local cave_frequent_volume = 1.0 
+local cave_frequent_volume = 1.0
 local water_frequent_frequency = 1000  --water sounds
-local water_frequent_volume = 1.0 
+local water_frequent_volume = 1.0
 local music_frequency = 7  --music (suggestion: keep this one low like around 6)
-local music_volume = 0.3 
+local music_volume = 0.3
 --End of Config
 ----------------------------------------------------------------------------------------------------
 local played_on_start = false
@@ -117,7 +117,7 @@ local lava2 = {
 	{name="earth01a", length=15}
 }
 
-local play_music = minetest.settings.get_bool("music") or false
+local play_music = minetest.settings:get_bool("music") or false
 local music = {
 	handler = {},
 	frequency = music_frequency,
@@ -173,7 +173,7 @@ local get_ambience = function(player)
 	end
 	if nodes_in_range(pos, 7, "default:lava_flowing")>5 or nodes_in_range(pos, 7, "default:lava_source")>5 then
 		if music then
-			return {lava=lava, lava2=lava2, music=music}		
+			return {lava=lava, lava2=lava2, music=music}
 		else
 			return {lava=lava}
 		end
@@ -332,7 +332,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
+	end
 	if still_playing.lava2 == nil then
 		local list = lava2
 		if list.handler[player_name] ~= nil then
@@ -342,7 +342,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end		
+	end
 	if still_playing.water == nil then
 		local list = water
 		if list.handler[player_name] ~= nil then
@@ -356,7 +356,7 @@ local stop_sound = function(still_playing, player)
 	if still_playing.water_frequent == nil then
 		local list = water_frequent
 		if list.handler[player_name] ~= nil then
-			if list.on_stop ~= nil then				
+			if list.on_stop ~= nil then
 				minetest.sound_play(list.on_stop, {to_player=player:get_player_name()})
 				played_on_start = false
 			end
@@ -381,7 +381,7 @@ minetest.register_globalstep(function(dtime)
 			if math.random(1, 1000) <= ambience.frequency then
 				if ambience.on_start ~= nil and played_on_start == false then
 					played_on_start = true
-					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})					
+					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})
 				end
 				play_sound(player, ambience, math.random(1, #ambience))
 			end

--- a/mods/ambience/Badinit.lua
+++ b/mods/ambience/Badinit.lua
@@ -5,26 +5,26 @@ local max_frequency_all = 1000 --the larger you make this number the lest freque
 
 --for frequencies below use a number between 0 and max_frequency_all
 --for volumes below, use a number between 0.0 and 1, the larger the number the louder the sounds
-local night_frequency = 20  --owls, wolves 
-local night_volume = 0.9  
+local night_frequency = 20  --owls, wolves
+local night_volume = 0.9
 local night_frequent_frequency = 150  --crickets
 local night_frequent_volume = 0.9
 local day_frequency = 100  --crow, bluejay, cardinal
-local day_volume = 0.9 
+local day_volume = 0.9
 local day_frequent_frequency = 1000  --crow, bluejay, cardinal
 local day_frequent_volume = 0.18
 local cave_frequency = 10  --bats
-local cave_volume = 1.0  
+local cave_volume = 1.0
 local cave_frequent_frequency = 70  --drops of water dripping
-local cave_frequent_volume = 1.0 
+local cave_frequent_volume = 1.0
 local beach_frequency = 20  --seagulls
-local beach_volume = 1.0  
+local beach_volume = 1.0
 local beach_frequent_frequency = 1000  --waves
-local beach_frequent_volume = 1.0 
+local beach_frequent_volume = 1.0
 local water_frequent_frequency = 1000  --water sounds
-local water_frequent_volume = 1.0 
+local water_frequent_volume = 1.0
 local music_frequency = 7  --music (suggestion: keep this one low like around 6)
-local music_volume = 0.3 
+local music_volume = 0.3
 --End of Config
 ----------------------------------------------------------------------------------------------------
 local played_on_start = false
@@ -135,7 +135,7 @@ local lava2 = {
 }
 
 
-local play_music = minetest.settings.get_bool("music") or false
+local play_music = minetest.settings:get_bool("music") or false
 local music = {
 	handler = {},
 	frequency = music_frequency,
@@ -191,7 +191,7 @@ local get_ambience = function(player)
 	end
 	if nodes_in_range(pos, 7, "default:lava_flowing")>5 or nodes_in_range(pos, 7, "default:lava_source")>5 then
 		if music then
-			return {lava=lava, lava2=lava2, music=music}		
+			return {lava=lava, lava2=lava2, music=music}
 		else
 			return {lava=lava}
 		end
@@ -203,7 +203,7 @@ local get_ambience = function(player)
 			return {flowing_water=flowing_water, flowing_water2=flowing_water2}
 		end
 	end
-	pos.y = pos.y-2 
+	pos.y = pos.y-2
 	nodename = minetest.env:get_node(pos).name
 	--minetest.chat_send_all("Found " .. nodename .. pos.y )
 	if string.find(nodename, "default:sand") and pos.y < 5 then
@@ -381,7 +381,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
+	end
 	if still_playing.lava2 == nil then
 		local list = lava2
 		if list.handler[player_name] ~= nil then
@@ -391,7 +391,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end		
+	end
 	if still_playing.water == nil then
 		local list = water
 		if list.handler[player_name] ~= nil then
@@ -405,7 +405,7 @@ local stop_sound = function(still_playing, player)
 	if still_playing.water_frequent == nil then
 		local list = water_frequent
 		if list.handler[player_name] ~= nil then
-			if list.on_stop ~= nil then				
+			if list.on_stop ~= nil then
 				minetest.sound_play(list.on_stop, {to_player=player:get_player_name()})
 				played_on_start = false
 			end
@@ -430,7 +430,7 @@ minetest.register_globalstep(function(dtime)
 			if math.random(1, 1000) <= ambience.frequency then
 				if ambience.on_start ~= nil and played_on_start == false then
 					played_on_start = true
-					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})					
+					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})
 				end
 				play_sound(player, ambience, math.random(1, #ambience))
 			end

--- a/mods/ambience/init.lua
+++ b/mods/ambience/init.lua
@@ -15,28 +15,28 @@ local max_frequency_all = 1000 --the larger you make this number the lest freque
 
 --for frequencies below use a number between 0 and max_frequency_all
 --for volumes below, use a number between 0.0 and 1, the larger the number the louder the sounds
-local night_frequency = 20  --owls, wolves 
-local night_volume = 0.9  
+local night_frequency = 20  --owls, wolves
+local night_volume = 0.9
 local night_frequent_frequency = 150  --crickets
 local night_frequent_volume = 0.9
 local day_frequency = 80  --crow, bluejay, cardinal
-local day_volume = 0.9 
+local day_volume = 0.9
 local day_frequent_frequency = 250  --crow, bluejay, cardinal
 local day_frequent_volume = 0.18
 local cave_frequency = 10  --bats
-local cave_volume = 1.0  
+local cave_volume = 1.0
 local cave_frequent_frequency = 70  --drops of water dripping
-local cave_frequent_volume = 1.0 
+local cave_frequent_volume = 1.0
 local beach_frequency = 20  --seagulls
-local beach_volume = 1.0  
+local beach_volume = 1.0
 local beach_frequent_frequency = 1000  --waves
-local beach_frequent_volume = 1.0 
+local beach_frequent_volume = 1.0
 local water_frequent_frequency = 1000  --water sounds
-local water_frequent_volume = 1.0 
+local water_frequent_volume = 1.0
 local desert_frequency = 20  --coyote
-local desert_volume = 1.0  
+local desert_volume = 1.0
 local desert_frequent_frequency = 700  --desertwind
-local desert_frequent_volume = 1.0 
+local desert_frequent_volume = 1.0
 local swimming_frequent_frequency = 1000  --swimming splashes
 local swimming_frequent_volume = 0
 local water_surface_volume = 0   -- sloshing water
@@ -44,7 +44,7 @@ local lava_volume = 0.8 --lava
 local flowing_water_volume = .4  --waterfall
 local splashing_water_volume = 1
 local music_frequency = 7  --music (suggestion: keep this one low like around 6)
-local music_volume = 0.3 
+local music_volume = 0.3
 
 --End of Config
 ----------------------------------------------------------------------------------------------------
@@ -228,7 +228,7 @@ local lava2 = {
 }
 
 
-local play_music = minetest.settings.get_bool("music") or false
+local play_music = minetest.settings:get_bool("music") or false
 local music = {
 	handler = {},
 	frequency = music_frequency,
@@ -284,7 +284,7 @@ local atleast_nodes_in_grid = function(pos, search_distance, height, node_name, 
 	totalnodes = totalnodes + #nodes
 	maxp = {x=pos.x+20,y=height, z=pos.z+search_distance}
 	minp = {x=pos.x+20,y=height, z=pos.z-search_distance}
-	nodes = minetest.env:find_nodes_in_area(minp, maxp, node_name)	
+	nodes = minetest.env:find_nodes_in_area(minp, maxp, node_name)
 --	minetest.chat_send_all("x+Found (" .. node_name .. ": " .. #nodes .. ")")
 	if #nodes >= threshold then
 		return true
@@ -292,8 +292,8 @@ local atleast_nodes_in_grid = function(pos, search_distance, height, node_name, 
 	totalnodes = totalnodes + #nodes
 	maxp = {x=pos.x-20,y=height, z=pos.z+search_distance}
 	minp = {x=pos.x-20,y=height, z=pos.z-search_distance}
-	nodes = minetest.env:find_nodes_in_area(minp, maxp, node_name)	
---	minetest.chat_send_all("x+Found (" .. node_name .. ": " .. #nodes .. ")")	
+	nodes = minetest.env:find_nodes_in_area(minp, maxp, node_name)
+--	minetest.chat_send_all("x+Found (" .. node_name .. ": " .. #nodes .. ")")
 	if #nodes >= threshold then
 		return true
 	end
@@ -301,7 +301,7 @@ local atleast_nodes_in_grid = function(pos, search_distance, height, node_name, 
 --	minetest.chat_send_all("Found total(" .. totalnodes .. ")")
 	if totalnodes >= threshold*2 then
 		return true
-	end	
+	end
 	return false
 end
 
@@ -313,11 +313,11 @@ local get_immediate_nodes = function(pos)
 	pos.y = pos.y+3
 	pos.y = pos.y+2.2
 	node_at_upper_body = minetest.env:get_node(pos).name
-	pos.y = pos.y-1.19   
+	pos.y = pos.y-1.19
 	node_at_lower_body = minetest.env:get_node(pos).name
-	pos.y = pos.y+0.99  
+	pos.y = pos.y+0.99
 	--minetest.chat_send_all("node_under_feet(" .. nodename .. ")")
-end 
+end
 
 
 local get_ambience = function(player)
@@ -328,20 +328,20 @@ local get_ambience = function(player)
 	local pos = player:getpos()
 	get_immediate_nodes(pos)
 
-	if last_x_pos ~=pos.x or last_z_pos ~=pos.z then 
-		player_is_moving_horiz = true 
+	if last_x_pos ~=pos.x or last_z_pos ~=pos.z then
+		player_is_moving_horiz = true
 	end
-	if pos.y > last_y_pos+.5   then 
-		player_is_climbing = true 
+	if pos.y > last_y_pos+.5   then
+		player_is_climbing = true
 	end
-	if pos.y < last_y_pos-.5  then 
-		player_is_descending = true 
+	if pos.y < last_y_pos-.5  then
+		player_is_descending = true
 	end
-	
+
 	last_x_pos =pos.x
-	last_z_pos =pos.z	
+	last_z_pos =pos.z
 	last_y_pos =pos.y
-	
+
 	if string.find(node_at_upper_body, "default:water") then
 		if music then
 			return {water=water, water_frequent=water_frequent, music=music}
@@ -356,20 +356,20 @@ local get_ambience = function(player)
 			--swimming 			w, m swimming
 			--walking in water  nw, m splashing
 			--treading water    w, nm  sloshing
-			--standing in water nw, nm	beach trumps, then sloshing					
+			--standing in water nw, nm	beach trumps, then sloshing
 			if player_is_moving_horiz then
 				if string.find(node_under_feet, "default:water") then
 					if music then
 						return {swimming_frequent=swimming_frequent, music=music}
 					else
 						return {swimming_frequent}
-					end	
-				else --didn't find water under feet: walking in water			
+					end
+				else --didn't find water under feet: walking in water
 					if music then
 						return {splashing_water=splashing_water, music=music}
 					else
 						return {splashing_water}
-					end	
+					end
 				end
 			else--player is not moving: treading water
 				if string.find(node_under_feet, "default:water") then
@@ -377,25 +377,25 @@ local get_ambience = function(player)
 						return {water_surface=water_surface, music=music}
 					else
 						return {water_surface}
-					end	
-				else --didn't find water under feet				
+					end
+				else --didn't find water under feet
 					standing_in_water = true
-				end			
+				end
 		    end
-		end	
+		end
 	end
 --	minetest.chat_send_all("----------")
 --	if not player_is_moving_horiz then
 --		minetest.chat_send_all("not moving horiz")
 --	else
 --		minetest.chat_send_all("moving horiz")
---	end	
+--	end
 --	minetest.chat_send_all("nub:" ..node_at_upper_body)
 --	minetest.chat_send_all("nlb:" ..node_at_lower_body)
 --	minetest.chat_send_all("nuf:" ..node_under_feet)
 --	minetest.chat_send_all("----------")
-	
-	
+
+
 --	if player_is_moving_horiz then
 --		minetest.chat_send_all("playermoving")
 --	end
@@ -406,7 +406,7 @@ local get_ambience = function(player)
 --	minetest.chat_send_all("nlb:" ..node_at_lower_body)
 --	minetest.chat_send_all("nuf:" ..node_under_feet)
 --	minetest.chat_send_all("n3uf:" ..node_3_under_feet)
---	
+--
 	local air_or_ignore = {air=true,ignore=true}
 	minp = {x=pos.x-3,y=pos.y-4, z=pos.z-3}
 	maxp = {x=pos.x+3,y=pos.y-1, z=pos.z+3}
@@ -419,19 +419,19 @@ local get_ambience = function(player)
 --	minetest.chat_send_all("counter: (" .. counter .. "-----------------)")
 	--minetest.chat_send_all(air_or_ignore[node_under_feet])
 --	if (player_is_moving_horiz or player_is_climbing) and air_or_ignore[node_at_upper_body] and air_or_ignore[node_at_lower_body]
---	 and air_or_ignore[node_under_feet] and air_plus_ignore_under == 196 and not player_is_descending then 
-	--minetest.chat_send_all("flying!!!!")	
+--	 and air_or_ignore[node_under_feet] and air_plus_ignore_under == 196 and not player_is_descending then
+	--minetest.chat_send_all("flying!!!!")
 	--	if music then
 		--	return {flying=flying, music=music}
 	--	else
 		---	return {flying}
---		end	
+--		end
 --	end
-	--minetest.chat_send_all("not flying!!!!")	
+	--minetest.chat_send_all("not flying!!!!")
 
 	if nodes_in_range(pos, 7, "default:lava_flowing")>5 or nodes_in_range(pos, 7, "default:lava_source")>5 then
 		if music then
-			return {lava=lava, lava2=lava2, music=music}		
+			return {lava=lava, lava2=lava2, music=music}
 		else
 			return {lava=lava}
 		end
@@ -442,7 +442,7 @@ local get_ambience = function(player)
 		else
 			return {flowing_water=flowing_water, flowing_water2=flowing_water2}
 		end
-	end	
+	end
 
 
 --if we are near sea level and there is lots of water around the area
@@ -451,17 +451,17 @@ local get_ambience = function(player)
 			return {beach=beach, beach_frequent=beach_frequent, beach_frequent2=beach_frequent2, music=music}
 		else
 			return {beach=beach, beach_frequent=beach_frequent, beach_frequent2=beach_frequent2}
-		end		
+		end
 	end
 	if standing_in_water then
 		if music then
 			return {water_surface=water_surface, music=music}
 		else
 			return {water_surface}
-		end	
+		end
 	end
-	
-	
+
+
 	desert_in_range = (nodes_in_range(pos, 6, "default:desert_sand")+nodes_in_range(pos, 6, "default:desert_stone"))
 	--minetest.chat_send_all("desertcount: " .. desert_in_range .. ",".. pos.y )
 	if  desert_in_range >250 then
@@ -470,12 +470,12 @@ local get_ambience = function(player)
 		else
 			return {desert=desert, desert_frequent=desert_frequent}
 		end
-	end	
+	end
 
---	pos.y = pos.y-2 
+--	pos.y = pos.y-2
 --	nodename = minetest.env:get_node(pos).name
 --	minetest.chat_send_all("Found " .. nodename .. pos.y )
-	
+
 
 	if player:getpos().y < 0 then
 		if music then
@@ -505,11 +505,11 @@ local play_sound = function(player, list, number, is_music)
 	if list.handler[player_name] == nil then
 		local gain = 1.0
 		if list[number].gain ~= nil then
-			if is_music then 				
+			if is_music then
 				gain = list[number].gain*MUSICVOLUME
 				--minetest.chat_send_all("gain music: " .. gain )
 			else
-				gain = list[number].gain*SOUNDVOLUME 
+				gain = list[number].gain*SOUNDVOLUME
 				--minetest.chat_send_all("gain sound: " .. gain )
 			end
 		end
@@ -700,7 +700,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
+	end
 	if still_playing.lava2 == nil then
 		local list = lava2
 		if list.handler[player_name] ~= nil then
@@ -710,7 +710,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end		
+	end
 	if still_playing.water == nil then
 		local list = water
 		if list.handler[player_name] ~= nil then
@@ -724,7 +724,7 @@ local stop_sound = function(still_playing, player)
 	if still_playing.water_surface == nil then
 		local list = water_surface
 		if list.handler[player_name] ~= nil then
-			if list.on_stop ~= nil then				
+			if list.on_stop ~= nil then
 				minetest.sound_play(list.on_stop, {to_player=player:get_player_name(),gain=SOUNDVOLUME})
 				played_on_start = false
 			end
@@ -735,9 +735,9 @@ local stop_sound = function(still_playing, player)
 	if still_playing.water_frequent == nil then
 		local list = water_frequent
 		if list.handler[player_name] ~= nil then
-			if list.on_stop ~= nil then				
+			if list.on_stop ~= nil then
 				minetest.sound_play(list.on_stop, {to_player=player:get_player_name(),gain=SOUNDVOLUME})
-		--		minetest.chat_send_all("list.on_stop " .. list.on_stop  )				
+		--		minetest.chat_send_all("list.on_stop " .. list.on_stop  )
 				played_on_start = false
 			end
 			minetest.sound_stop(list.handler[player_name])
@@ -757,7 +757,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
+	end
 	if still_playing.splashing_water == nil then
 		local list = splashing_water
 		if list.handler[player_name] ~= nil then
@@ -767,8 +767,8 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
-	
+	end
+
 end
 
 local timer = 0
@@ -783,7 +783,7 @@ minetest.register_globalstep(function(dtime)
 		ambiences = get_ambience(player)
 		stop_sound(ambiences, player)
 		for _,ambience in pairs(ambiences) do
-			if math.random(1, 1000) <= ambience.frequency then			
+			if math.random(1, 1000) <= ambience.frequency then
 --				if(played_on_start) then
 --				--	minetest.chat_send_all("playedOnStart "  )
 --				else
@@ -791,12 +791,12 @@ minetest.register_globalstep(function(dtime)
 --				end
 				if ambience.on_start ~= nil and played_on_start == false then
 					played_on_start = true
-					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name(),gain=SOUNDVOLUME})					
+					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name(),gain=SOUNDVOLUME})
 				end
 			--	minetest.chat_send_all("ambience: " ..ambience )
 			--	if ambience.on_start ~= nil and played_on_start_flying == false then
 			--		played_on_start_flying = true
-			--		minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})					
+			--		minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})
 			--	end
 				local is_music =false
 				if ambience.is_music ~= nil then
@@ -827,6 +827,6 @@ minetest.register_chatcommand("mvol", {
 		MUSICVOLUME = param
 	--	local player = minetest.env:get_player_by_name(name)
 	--	stop_sound({}, player)
-	--	ambiences = get_ambience(player)	
+	--	ambiences = get_ambience(player)
 		minetest.chat_send_player(name, "Music volume set.")
-	end,		})	
+	end,		})

--- a/mods/ambience/init.lua.pilz.lua
+++ b/mods/ambience/init.lua.pilz.lua
@@ -69,7 +69,7 @@ local splash = {
 	{name="Splash", length=1.5},
 }
 
-local play_music = minetest.settings.get_bool("music") or false
+local play_music = minetest.settings:get_bool("music") or false
 local music = {
 	handler = {},
 	frequency = 1,

--- a/mods/ambience/init16.lua
+++ b/mods/ambience/init16.lua
@@ -5,26 +5,26 @@ local max_frequency_all = 1000 --the larger you make this number the lest freque
 
 --for frequencies below use a number between 0 and max_frequency_all
 --for volumes below, use a number between 0.0 and 1, the larger the number the louder the sounds
-local night_frequency = 20  --owls, wolves 
-local night_volume = 0.9  
+local night_frequency = 20  --owls, wolves
+local night_volume = 0.9
 local night_frequent_frequency = 150  --crickets
 local night_frequent_volume = 0.9
 local day_frequency = 100  --crow, bluejay, cardinal
-local day_volume = 0.9 
+local day_volume = 0.9
 local day_frequent_frequency = 1000  --crow, bluejay, cardinal
 local day_frequent_volume = 0.18
 local cave_frequency = 10  --bats
-local cave_volume = 1.0  
+local cave_volume = 1.0
 local cave_frequent_frequency = 70  --drops of water dripping
-local cave_frequent_volume = 1.0 
+local cave_frequent_volume = 1.0
 local beach_frequency = 20  --seagulls
-local beach_volume = 1.0  
+local beach_volume = 1.0
 local beach_frequent_frequency = 1000  --waves
-local beach_frequent_volume = 1.0 
+local beach_frequent_volume = 1.0
 local water_frequent_frequency = 1000  --water sounds
-local water_frequent_volume = 1.0 
+local water_frequent_volume = 1.0
 local music_frequency = 7  --music (suggestion: keep this one low like around 6)
-local music_volume = 0.3 
+local music_volume = 0.3
 --End of Config
 ----------------------------------------------------------------------------------------------------
 local played_on_start = false
@@ -135,7 +135,7 @@ local lava2 = {
 }
 
 
-local play_music = minetest.settings.get_bool("music") or false
+local play_music = minetest.settings:get_bool("music") or false
 local music = {
 	handler = {},
 	frequency = music_frequency,
@@ -191,7 +191,7 @@ local get_ambience = function(player)
 	end
 	if nodes_in_range(pos, 7, "default:lava_flowing")>5 or nodes_in_range(pos, 7, "default:lava_source")>5 then
 		if music then
-			return {lava=lava, lava2=lava2, music=music}		
+			return {lava=lava, lava2=lava2, music=music}
 		else
 			return {lava=lava}
 		end
@@ -203,7 +203,7 @@ local get_ambience = function(player)
 			return {flowing_water=flowing_water, flowing_water2=flowing_water2}
 		end
 	end
-	pos.y = pos.y-2 
+	pos.y = pos.y-2
 	nodename = minetest.env:get_node(pos).name
 	--minetest.chat_send_all("Found " .. nodename .. pos.y )
 	if string.find(nodename, "default:sand") and pos.y < 5 then
@@ -381,7 +381,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
+	end
 	if still_playing.lava2 == nil then
 		local list = lava2
 		if list.handler[player_name] ~= nil then
@@ -391,7 +391,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end		
+	end
 	if still_playing.water == nil then
 		local list = water
 		if list.handler[player_name] ~= nil then
@@ -405,7 +405,7 @@ local stop_sound = function(still_playing, player)
 	if still_playing.water_frequent == nil then
 		local list = water_frequent
 		if list.handler[player_name] ~= nil then
-			if list.on_stop ~= nil then				
+			if list.on_stop ~= nil then
 				minetest.sound_play(list.on_stop, {to_player=player:get_player_name()})
 				played_on_start = false
 			end
@@ -430,7 +430,7 @@ minetest.register_globalstep(function(dtime)
 			if math.random(1, 1000) <= ambience.frequency then
 				if ambience.on_start ~= nil and played_on_start == false then
 					played_on_start = true
-					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})					
+					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})
 				end
 				play_sound(player, ambience, math.random(1, #ambience))
 			end

--- a/mods/ambience/init17.lua
+++ b/mods/ambience/init17.lua
@@ -5,26 +5,26 @@ local max_frequency_all = 1000 --the larger you make this number the lest freque
 
 --for frequencies below use a number between 0 and max_frequency_all
 --for volumes below, use a number between 0.0 and 1, the larger the number the louder the sounds
-local night_frequency = 20  --owls, wolves 
-local night_volume = 0.9  
+local night_frequency = 20  --owls, wolves
+local night_volume = 0.9
 local night_frequent_frequency = 150  --crickets
 local night_frequent_volume = 0.9
 local day_frequency = 100  --crow, bluejay, cardinal
-local day_volume = 0.9 
+local day_volume = 0.9
 local day_frequent_frequency = 1000  --crow, bluejay, cardinal
 local day_frequent_volume = 0.18
 local cave_frequency = 10  --bats
-local cave_volume = 1.0  
+local cave_volume = 1.0
 local cave_frequent_frequency = 70  --drops of water dripping
-local cave_frequent_volume = 1.0 
+local cave_frequent_volume = 1.0
 local beach_frequency = 20  --seagulls
-local beach_volume = 1.0  
+local beach_volume = 1.0
 local beach_frequent_frequency = 1000  --waves
-local beach_frequent_volume = 1.0 
+local beach_frequent_volume = 1.0
 local water_frequent_frequency = 1000  --water sounds
-local water_frequent_volume = 1.0 
+local water_frequent_volume = 1.0
 local music_frequency = 0  --music (suggestion: keep this one low like around 6)
-local music_volume = 0.3 
+local music_volume = 0.3
 --End of Config
 ----------------------------------------------------------------------------------------------------
 local played_on_start = false
@@ -143,7 +143,7 @@ local lava2 = {
 }
 
 
-local play_music = minetest.settings.get_bool("music") or false
+local play_music = minetest.settings:get_bool("music") or false
 local music = {
 	handler = {},
 	frequency = music_frequency,
@@ -205,13 +205,13 @@ local get_ambience = function(player)
 				return {water_surface=water_surface, music=music}
 			else
 				return {water_surface}
-			end		
-		end	
+			end
+		end
 	end
 
 	if nodes_in_range(pos, 7, "default:lava_flowing")>5 or nodes_in_range(pos, 7, "default:lava_source")>5 then
 		if music then
-			return {lava=lava, lava2=lava2, music=music}		
+			return {lava=lava, lava2=lava2, music=music}
 		else
 			return {lava=lava}
 		end
@@ -222,8 +222,8 @@ local get_ambience = function(player)
 		else
 			return {flowing_water=flowing_water, flowing_water2=flowing_water2}
 		end
-	end	
-	pos.y = pos.y-2 
+	end
+	pos.y = pos.y-2
 	nodename = minetest.env:get_node(pos).name
 	--minetest.chat_send_all("Found " .. nodename .. pos.y )
 	if string.find(nodename, "default:sand") and pos.y < 5 then
@@ -401,7 +401,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
+	end
 	if still_playing.lava2 == nil then
 		local list = lava2
 		if list.handler[player_name] ~= nil then
@@ -411,7 +411,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end		
+	end
 	if still_playing.water == nil then
 		local list = water
 		if list.handler[player_name] ~= nil then
@@ -425,7 +425,7 @@ local stop_sound = function(still_playing, player)
 	if still_playing.water_surface == nil then
 		local list = water_surface
 		if list.handler[player_name] ~= nil then
-			if list.on_stop ~= nil then				
+			if list.on_stop ~= nil then
 				minetest.sound_play(list.on_stop, {to_player=player:get_player_name()})
 				played_on_start = false
 			end
@@ -436,9 +436,9 @@ local stop_sound = function(still_playing, player)
 	if still_playing.water_frequent == nil then
 		local list = water_frequent
 		if list.handler[player_name] ~= nil then
-			if list.on_stop ~= nil then				
+			if list.on_stop ~= nil then
 				minetest.sound_play(list.on_stop, {to_player=player:get_player_name()})
-				minetest.chat_send_all("list.on_stop " .. list.on_stop  )				
+				minetest.chat_send_all("list.on_stop " .. list.on_stop  )
 		--		played_on_start = false
 			end
 			minetest.sound_stop(list.handler[player_name])
@@ -447,7 +447,7 @@ local stop_sound = function(still_playing, player)
 	end
 
 
-	
+
 end
 
 local timer = 0
@@ -465,7 +465,7 @@ minetest.register_globalstep(function(dtime)
 			if math.random(1, 1000) <= ambience.frequency then
 				if ambience.on_start ~= nil and played_on_start == false then
 					played_on_start = true
-					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})					
+					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})
 				end
 				play_sound(player, ambience, math.random(1, #ambience))
 			end

--- a/mods/ambience/init29debug.lua
+++ b/mods/ambience/init29debug.lua
@@ -1,5 +1,5 @@
 --------------------------------------------------------------------------------------------------------
---Ambiance Configuration for version .29   
+--Ambiance Configuration for version .29
 --working on Flying
 --PROB:  wind stops short even though it says we are still flying and don't hear the start sound.
 --really BIG prob, it ruins water meaning you hear beach while treading water.  (find out if still hear it in .28) because
@@ -11,32 +11,32 @@ local max_frequency_all = 1000 --the larger you make this number the lest freque
 
 --for frequencies below use a number between 0 and max_frequency_all
 --for volumes below, use a number between 0.0 and 1, the larger the number the louder the sounds
-local night_frequency = 20  --owls, wolves 
-local night_volume = 0.9  
+local night_frequency = 20  --owls, wolves
+local night_volume = 0.9
 local night_frequent_frequency = 150  --crickets
 local night_frequent_volume = 0.9
 local day_frequency = 100  --crow, bluejay, cardinal
-local day_volume = 0.9 
+local day_volume = 0.9
 local day_frequent_frequency = 1000  --crow, bluejay, cardinal
 local day_frequent_volume = 0.18
 local cave_frequency = 10  --bats
-local cave_volume = 1.0  
+local cave_volume = 1.0
 local cave_frequent_frequency = 70  --drops of water dripping
-local cave_frequent_volume = 1.0 
+local cave_frequent_volume = 1.0
 local beach_frequency = 20  --seagulls
-local beach_volume = 1.0  
+local beach_volume = 1.0
 local beach_frequent_frequency = 1000  --waves
-local beach_frequent_volume = 1.0 
+local beach_frequent_volume = 1.0
 local water_frequent_frequency = 1000  --water sounds
-local water_frequent_volume = 1.0 
+local water_frequent_volume = 1.0
 local desert_frequency = 20  --coyote
-local desert_volume = 1.0  
+local desert_volume = 1.0
 local desert_frequent_frequency = 700  --desertwind
-local desert_frequent_volume = 1.0 
+local desert_frequent_volume = 1.0
 local swimming_frequent_frequency = 1000  --swimming splashes
-local swimming_frequent_volume = 1.0 
+local swimming_frequent_volume = 1.0
 local music_frequency = 0  --music (suggestion: keep this one low like around 6)
-local music_volume = 0.3 
+local music_volume = 0.3
 --End of Config
 ----------------------------------------------------------------------------------------------------
 local counter=0--*****************
@@ -197,7 +197,7 @@ local lava2 = {
 }
 
 
-local play_music = minetest.settings.get_bool("music") or false
+local play_music = minetest.settings:get_bool("music") or false
 local music = {
 	handler = {},
 	frequency = music_frequency,
@@ -248,7 +248,7 @@ local atleast_nodes_in_grid = function(pos, search_distance, height, node_name, 
 	totalnodes = totalnodes + #nodes
 	maxp = {x=pos.x+20,y=height, z=pos.z+search_distance}
 	minp = {x=pos.x+20,y=height, z=pos.z-search_distance}
-	nodes = minetest.env:find_nodes_in_area(minp, maxp, node_name)	
+	nodes = minetest.env:find_nodes_in_area(minp, maxp, node_name)
 --	minetest.chat_send_all("x+Found (" .. node_name .. ": " .. #nodes .. ")")
 	if #nodes >= threshold then
 		return true
@@ -256,8 +256,8 @@ local atleast_nodes_in_grid = function(pos, search_distance, height, node_name, 
 	totalnodes = totalnodes + #nodes
 	maxp = {x=pos.x-20,y=height, z=pos.z+search_distance}
 	minp = {x=pos.x-20,y=height, z=pos.z-search_distance}
-	nodes = minetest.env:find_nodes_in_area(minp, maxp, node_name)	
---	minetest.chat_send_all("x+Found (" .. node_name .. ": " .. #nodes .. ")")	
+	nodes = minetest.env:find_nodes_in_area(minp, maxp, node_name)
+--	minetest.chat_send_all("x+Found (" .. node_name .. ": " .. #nodes .. ")")
 	if #nodes >= threshold then
 		return true
 	end
@@ -265,7 +265,7 @@ local atleast_nodes_in_grid = function(pos, search_distance, height, node_name, 
 --	minetest.chat_send_all("Found total(" .. totalnodes .. ")")
 	if totalnodes >= threshold*2 then
 		return true
-	end	
+	end
 	return false
 end
 
@@ -277,11 +277,11 @@ local get_immediate_nodes = function(pos)
 	pos.y = pos.y+3
 	pos.y = pos.y+2.2
 	node_at_upper_body = minetest.env:get_node(pos).name
-	pos.y = pos.y-1.19   
+	pos.y = pos.y-1.19
 	node_at_lower_body = minetest.env:get_node(pos).name
 	pos.y = pos.y+0.99   --1.6
 	--minetest.chat_send_all("node_under_feet(" .. nodename .. ")")
-end 
+end
 
 
 local get_ambience = function(player)
@@ -292,20 +292,20 @@ local get_ambience = function(player)
 	local pos = player:getpos()
 	get_immediate_nodes(pos)
 
-	if last_x_pos ~=pos.x or last_z_pos ~=pos.z then 
-		player_is_moving_horiz = true 
+	if last_x_pos ~=pos.x or last_z_pos ~=pos.z then
+		player_is_moving_horiz = true
 	end
-	if pos.y > last_y_pos+.5   then 
-		player_is_climbing = true 
+	if pos.y > last_y_pos+.5   then
+		player_is_climbing = true
 	end
-	if pos.y < last_y_pos-.5  then 
-		player_is_descending = true 
+	if pos.y < last_y_pos-.5  then
+		player_is_descending = true
 	end
-	
+
 	last_x_pos =pos.x
-	last_z_pos =pos.z	
+	last_z_pos =pos.z
 	last_y_pos =pos.y
-	
+
 	if string.find(node_at_upper_body, "default:water") then
 		if music then
 			return {water=water, water_frequent=water_frequent, music=music}
@@ -320,20 +320,20 @@ local get_ambience = function(player)
 			--swimming 			w, m swimming
 			--walking in water  nw, m splashing
 			--treading water    w, nm  sloshing
-			--standing in water nw, nm	beach trumps, then sloshing					
+			--standing in water nw, nm	beach trumps, then sloshing
 			if player_is_moving_horiz then
 				if string.find(node_under_feet, "default:water") then
 					if music then
 						return {swimming_frequent=swimming_frequent, music=music}
 					else
 						return {swimming_frequent}
-					end	
-				else --didn't find water under feet: walking in water			
+					end
+				else --didn't find water under feet: walking in water
 					if music then
 						return {splashing_water=splashing_water, music=music}
 					else
 						return {splashing_water}
-					end	
+					end
 				end
 			else--player is not moving
 				if string.find(node_under_feet, "default:water") then
@@ -341,12 +341,12 @@ local get_ambience = function(player)
 						return {water_surface=water_surface, music=music}
 					else
 						return {water_surface}
-					end	
-				else --didn't find water under feet				
+					end
+				else --didn't find water under feet
 					standing_in_water = true
-				end			
+				end
 		    end
-		end	
+		end
 	end
 	if player_is_moving_horiz then
 		minetest.chat_send_all("playermoving")
@@ -358,23 +358,23 @@ local get_ambience = function(player)
 	minetest.chat_send_all("nlb:" ..node_at_lower_body)
 	minetest.chat_send_all("nuf:" ..node_under_feet)
 	minetest.chat_send_all("n3uf:" ..node_3_under_feet)
-	
+
 	local air_or_ignore = {air=true,ignore=true}
 	--minetest.chat_send_all(air_or_ignore[node_under_feet])
 	if (player_is_moving_horiz or player_is_climbing) and air_or_ignore[node_at_upper_body] and air_or_ignore[node_at_lower_body]
-	 and air_or_ignore[node_under_feet] and air_or_ignore[node_3_under_feet] and not player_is_descending then 
-	minetest.chat_send_all("flying!!!!")	
+	 and air_or_ignore[node_under_feet] and air_or_ignore[node_3_under_feet] and not player_is_descending then
+	minetest.chat_send_all("flying!!!!")
 		if music then
 			return {flying=flying, music=music}
 		else
 			return {flying}
-		end	
+		end
 	end
-	minetest.chat_send_all("not flying!!!!")	
+	minetest.chat_send_all("not flying!!!!")
 
 	if nodes_in_range(pos, 7, "default:lava_flowing")>5 or nodes_in_range(pos, 7, "default:lava_source")>5 then
 		if music then
-			return {lava=lava, lava2=lava2, music=music}		
+			return {lava=lava, lava2=lava2, music=music}
 		else
 			return {lava=lava}
 		end
@@ -385,7 +385,7 @@ local get_ambience = function(player)
 		else
 			return {flowing_water=flowing_water, flowing_water2=flowing_water2}
 		end
-	end	
+	end
 
 
 --if we are near sea level and there is lots of water around the area
@@ -394,17 +394,17 @@ local get_ambience = function(player)
 			return {beach=beach, beach_frequent=beach_frequent, music=music}
 		else
 			return {beach=beach, beach_frequent=beach_frequent}
-		end		
+		end
 	end
 	if standing_in_water then
 		if music then
 			return {water_surface=water_surface, music=music}
 		else
 			return {water_surface}
-		end	
+		end
 	end
-	
-	
+
+
 	desert_in_range = (nodes_in_range(pos, 6, "default:desert_sand")+nodes_in_range(pos, 6, "default:desert_stone"))
 	--minetest.chat_send_all("desertcount: " .. desert_in_range .. ",".. pos.y )
 	if  desert_in_range >250 then
@@ -413,12 +413,12 @@ local get_ambience = function(player)
 		else
 			return {desert=desert, desert_frequent=desert_frequent}
 		end
-	end	
+	end
 
-	pos.y = pos.y-2 
+	pos.y = pos.y-2
 	nodename = minetest.env:get_node(pos).name
 --	minetest.chat_send_all("Found " .. nodename .. pos.y )
-	
+
 
 	if player:getpos().y < 0 then
 		if music then
@@ -617,7 +617,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
+	end
 	if still_playing.lava2 == nil then
 		local list = lava2
 		if list.handler[player_name] ~= nil then
@@ -627,7 +627,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end		
+	end
 	if still_playing.water == nil then
 		local list = water
 		if list.handler[player_name] ~= nil then
@@ -641,7 +641,7 @@ local stop_sound = function(still_playing, player)
 	if still_playing.water_surface == nil then
 		local list = water_surface
 		if list.handler[player_name] ~= nil then
-			if list.on_stop ~= nil then				
+			if list.on_stop ~= nil then
 				minetest.sound_play(list.on_stop, {to_player=player:get_player_name()})
 				played_on_start = false
 			end
@@ -652,9 +652,9 @@ local stop_sound = function(still_playing, player)
 	if still_playing.water_frequent == nil then
 		local list = water_frequent
 		if list.handler[player_name] ~= nil then
-			if list.on_stop ~= nil then				
+			if list.on_stop ~= nil then
 				minetest.sound_play(list.on_stop, {to_player=player:get_player_name()})
-		--		minetest.chat_send_all("list.on_stop " .. list.on_stop  )				
+		--		minetest.chat_send_all("list.on_stop " .. list.on_stop  )
 				played_on_start = false
 			end
 			minetest.sound_stop(list.handler[player_name])
@@ -674,7 +674,7 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
+	end
 	if still_playing.splashing_water == nil then
 		local list = splashing_water
 		if list.handler[player_name] ~= nil then
@@ -684,8 +684,8 @@ local stop_sound = function(still_playing, player)
 			minetest.sound_stop(list.handler[player_name])
 			list.handler[player_name] = nil
 		end
-	end	
-	
+	end
+
 end
 
 local timer = 0
@@ -700,7 +700,7 @@ minetest.register_globalstep(function(dtime)
 		local ambiences = get_ambience(player)
 		stop_sound(ambiences, player)
 		for _,ambience in pairs(ambiences) do
-			if math.random(1, 1000) <= ambience.frequency then			
+			if math.random(1, 1000) <= ambience.frequency then
 				if(played_on_start) then
 				--	minetest.chat_send_all("playedOnStart "  )
 				else
@@ -708,12 +708,12 @@ minetest.register_globalstep(function(dtime)
 				end
 				if ambience.on_start ~= nil and played_on_start == false then
 					played_on_start = true
-					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})					
+					minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})
 				end
 				minetest.chat_send_all("ambience: " ..ambience )
 			--	if ambience.on_start ~= nil and played_on_start_flying == false then
 			--		played_on_start_flying = true
-			--		minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})					
+			--		minetest.sound_play(ambience.on_start, {to_player=player:get_player_name()})
 			--	end
 				play_sound(player, ambience, math.random(1, #ambience))
 			end

--- a/mods/areas/init.lua
+++ b/mods/areas/init.lua
@@ -32,8 +32,7 @@ if not minetest.registered_privileges[areas.config.self_protection_privilege] th
 	})
 end
 
-if minetest.settings.get_bool("log_mod") then
+if minetest.settings:get_bool("log_mod") then
 	local diffTime = os.clock() - areas.startTime
 	minetest.log("action", "areas loaded in "..diffTime.."s.")
 end
-

--- a/mods/areas/settings.lua
+++ b/mods/areas/settings.lua
@@ -6,13 +6,13 @@ local function setting(tp, name, default)
 	local full_name = "areas."..name
 	local value
 	if tp == "boolean" then
-		value = minetest.settings.get_bool(full_name)
+		value = minetest.settings:get_bool(full_name)
 	elseif tp == "string" then
-		value = minetest.settings.get(full_name)
+		value = minetest.settings:get(full_name)
 	elseif tp == "position" then
 		value = minetest.setting_get_pos(full_name)
 	elseif tp == "number" then
-		value = tonumber(minetest.settings.get(full_name))
+		value = tonumber(minetest.settings:get(full_name))
 	else
 		error("Invalid setting type!")
 	end
@@ -40,4 +40,3 @@ setting("number",   "self_protection_max_areas_high", 32)
 
 -- legacy_table (owner_defs) compatibility.  Untested and has known issues.
 setting("boolean", "legacy_table", false)
-

--- a/mods/boats/init.lua
+++ b/mods/boats/init.lua
@@ -111,7 +111,7 @@ function boat.on_punch(self, puncher)
 		minetest.after(0.1, function()
 			self.object:remove()
 		end)
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			local inv = puncher:get_inventory()
 			if inv:room_for_item("main", "boats:boat") then
 				inv:add_item("main", "boats:boat")
@@ -229,7 +229,7 @@ minetest.register_craftitem("boats:boat", {
 		end
 		pointed_thing.under.y = pointed_thing.under.y + 0.5
 		minetest.add_entity(pointed_thing.under, "boats:boat")
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			itemstack:take_item()
 		end
 		return itemstack

--- a/mods/cake/init.lua
+++ b/mods/cake/init.lua
@@ -17,7 +17,7 @@ for i, size in ipairs(sizes) do
 	local description
 	local drop
 	local tiles
-	
+
 	if slice == 0 then
 		name = "cake:cake"
 		description = S("Cake")
@@ -28,7 +28,7 @@ for i, size in ipairs(sizes) do
 		drop = ''
 		tiles = {"cake_top.png", "cake_bottom.png", "cake_side.png", "cake_inner.png", "cake_side.png", "cake_side.png"}
 	end
-	
+
 	minetest.register_node(name, {
 		description = description,
 		drop = drop,
@@ -73,7 +73,7 @@ if not minetest.get_modpath("food") then
 		inventory_image = "cake_sugar.png",
 		groups = {food_sugar=1}
 	})
-	
+
 	minetest.register_craft({
 		type = "shapeless",
 		output = "cake:sugar",
@@ -89,7 +89,7 @@ minetest.register_craft({
 	recipe = {"farming:flour", "group:water_bucket", "group:food_sugar", "group:food_sugar"},
 	replacements = {
 		{"group:water_bucket", "bucket:bucket_empty"},
-		
+
 		-- Not needed >0.4.13
 		{"bucket:bucket_water", "bucket:bucket_empty"},
 		{"bucket:bucket_river_water", "bucket:bucket_empty"}
@@ -138,7 +138,7 @@ minetest.register_entity("cake:cake_entity", {
 if throwable_cake then
 	minetest.override_item("cake:cake", {
 		on_use = function(itemstack, player, pointed_thing)
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:take_item()
 			end
 			local playerpos = player:getpos()

--- a/mods/creative/init.lua
+++ b/mods/creative/init.lua
@@ -14,7 +14,7 @@ creative.init_creative_inventory = function(player)
 
 	local inv = minetest.create_detached_inventory("creative_" .. player_name, {
 		allow_move = function(inv, from_list, from_index, to_list, to_index, count, player)
-			if minetest.settings.get_bool("creative_mode") then
+			if minetest.settings:get_bool("creative_mode") then
 				return count
 			else
 				return 0
@@ -24,7 +24,7 @@ creative.init_creative_inventory = function(player)
 			return 0
 		end,
 		allow_take = function(inv, listname, index, stack, player)
-			if minetest.settings.get_bool("creative_mode") then
+			if minetest.settings:get_bool("creative_mode") then
 				return -1
 			else
 				return 0
@@ -84,7 +84,7 @@ local trash = minetest.create_detached_inventory("creative_trash", {
 	-- Allow the stack to be placed and remove it in on_put()
 	-- This allows the creative inventory to restore the stack
 	allow_put = function(inv, listname, index, stack, player)
-		if minetest.settings.get_bool("creative_mode") then
+		if minetest.settings:get_bool("creative_mode") then
 			return stack:get_count()
 		else
 			return 0
@@ -150,7 +150,7 @@ end
 
 minetest.register_on_joinplayer(function(player)
 	-- If in creative mode, modify player's inventory forms
-	if not minetest.settings.get_bool("creative_mode") then
+	if not minetest.settings:get_bool("creative_mode") then
 		return
 	end
 	creative.init_creative_inventory(player)
@@ -158,7 +158,7 @@ minetest.register_on_joinplayer(function(player)
 end)
 
 minetest.register_on_player_receive_fields(function(player, formname, fields)
-	if formname ~= "" or not minetest.settings.get_bool("creative_mode") then
+	if formname ~= "" or not minetest.settings:get_bool("creative_mode") then
 		return
 	end
 
@@ -211,7 +211,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 	end
 end)
 
-if minetest.settings.get_bool("creative_mode") then
+if minetest.settings:get_bool("creative_mode") then
 	local digtime = 0.5
 	minetest.register_item(":", {
 		type = "none",

--- a/mods/ctf_pvp_engine/ctf/core.lua
+++ b/mods/ctf_pvp_engine/ctf/core.lua
@@ -169,18 +169,18 @@ function ctf._set(setting, default)
 	end
 	ctf._defsettings[setting] = default
 
-	if minetest.settings.get("ctf."..setting) then
-		ctf.log("settings", "- " .. setting .. ": " .. minetest.settings.get("ctf."..setting))
-	elseif minetest.settings.get("ctf_"..setting) then
-		ctf.log("settings", "- " .. setting .. ": " .. minetest.settings.get("ctf_"..setting))
+	if minetest.settings:get("ctf."..setting) then
+		ctf.log("settings", "- " .. setting .. ": " .. minetest.settings:get("ctf."..setting))
+	elseif minetest.settings:get("ctf_"..setting) then
+		ctf.log("settings", "- " .. setting .. ": " .. minetest.settings:get("ctf_"..setting))
 		ctf.warning("settings", "deprecated setting ctf_"..setting..
 				" used, use ctf."..setting.." instead.")
 	end
 end
 
 function ctf.setting(name)
-	local set = minetest.settings.get("ctf."..name) or
-			minetest.settings.get("ctf_"..name)
+	local set = minetest.settings:get("ctf."..name) or
+			minetest.settings:get("ctf_"..name)
 	local dset = ctf._defsettings[name]
 	if dset == nil then
 		ctf.error("setting", "No such setting - " .. name)

--- a/mods/currency/init.lua
+++ b/mods/currency/init.lua
@@ -12,7 +12,7 @@ minetest.log("info", "[Currency] Shop Loaded!")
 --dofile(modpath.."/safe.lua")
 --minetest.log("info", "[Currency] Safe Loaded!")
 
---[[if minetest.settings.get_bool("creative_mode") then
+--[[if minetest.settings:get_bool("creative_mode") then
 	minetest.log("info", "[Currency] Creative mode in use, skipping basic income.")
 else
 	dofile(modpath.."/income.lua")

--- a/mods/fire/init.lua
+++ b/mods/fire/init.lua
@@ -270,7 +270,7 @@ minetest.register_abm({
 
 -- Enable the following ABMs according to 'disable fire' setting
 
-if minetest.settings.get_bool("disable_fire") then
+if minetest.settings:get_bool("disable_fire") then
 
 	-- Remove basic flames only
 

--- a/mods/give_initial_stuff/init.lua
+++ b/mods/give_initial_stuff/init.lua
@@ -1,6 +1,6 @@
 minetest.register_on_newplayer(function(player)
 	--print("on_newplayer")
-	if minetest.settings.get_bool("give_initial_stuff") then
+	if minetest.settings:get_bool("give_initial_stuff") then
 		minetest.log("action", "Giving initial stuff to player "..player:get_player_name())
             player:get_inventory():add_item('main', 'default:pick_stone')
 			player:get_inventory():add_item('main', 'xdecor:crafting_guide')

--- a/mods/hud/init.lua
+++ b/mods/hud/init.lua
@@ -49,7 +49,7 @@ HUD_TICK = 0.1
 --Some hunger settings
 hud.exhaustion = {} -- Exhaustion is experimental!
 
-HUD_HUNGER_TICK = 400 -- time in seconds after that 1 hunger point is taken 
+HUD_HUNGER_TICK = 400 -- time in seconds after that 1 hunger point is taken
 HUD_HUNGER_EXHAUST_DIG = 2  -- exhaustion increased this value after digged node
 HUD_HUNGER_EXHAUST_PLACE = 1 -- exhaustion increased this value after placed
 HUD_HUNGER_EXHAUST_MOVE = 0.3 -- exhaustion increased this value if player movement detected
@@ -57,9 +57,9 @@ HUD_HUNGER_EXHAUST_LVL = 160 -- at what exhaustion player saturation gets lowerd
 
 
 
-HUD_ENABLE_HUNGER = minetest.settings.get_bool("hud_hunger_enable")
+HUD_ENABLE_HUNGER = minetest.settings:get_bool("hud_hunger_enable")
 if HUD_ENABLE_HUNGER == nil then
-	HUD_ENABLE_HUNGER = minetest.settings.get_bool("enable_damage")
+	HUD_ENABLE_HUNGER = minetest.settings:get_bool("enable_damage")
 end
 
 HUD_SHOW_ARMOR = false
@@ -69,7 +69,7 @@ end
 
 --load custom settings
 local set = io.open(minetest.get_modpath("hud").."/hud.conf", "r")
-if set then 
+if set then
 	dofile(minetest.get_modpath("hud").."/hud.conf")
 	set:close()
 else
@@ -92,7 +92,7 @@ local function custom_hud(player)
 	player:hud_set_hotbar_selected_image("hud_hotbar_selected.png")
  end
 
- if minetest.settings.get_bool("enable_damage") then
+ if minetest.settings:get_bool("enable_damage") then
  --hunger
 	if HUD_ENABLE_HUNGER then
        	 player:hud_add({
@@ -243,7 +243,7 @@ hud.set_hunger = function(player)
 	if not inv  or not value then return nil end
 	if value > 30 then value = 30 end
 	if value < 0 then value = 0 end
-	
+
 	inv:set_stack("hunger", 1, ItemStack({name=":", count=value+1}))
 
 	return true
@@ -296,7 +296,7 @@ minetest.after(10, function() --originally 2.5
 			local name = player:get_player_name()
 
 			-- only proceed if damage is enabled
-			if minetest.settings.get_bool("enable_damage") then
+			if minetest.settings:get_bool("enable_damage") then
 			 local h = tonumber(hud.hunger[name])
 			 local hp = player:get_hp()
 			 if HUD_ENABLE_HUNGER and timer > 10 then
@@ -304,7 +304,7 @@ minetest.after(10, function() --originally 2.5
 				if h > 15 and hp > 0 and hud.air[name] > 0 then
 					player:set_hp(hp+1)
 				-- or damage player by 1 hp if saturation is < 2 (of 30)
-				elseif h <= 1 and minetest.settings.get_bool("enable_damage") then
+				elseif h <= 1 and minetest.settings:get_bool("enable_damage") then
 					if hp-1 >= 0 then player:set_hp(hp-1) end
 				end
 			 end
@@ -321,7 +321,7 @@ minetest.after(10, function() --originally 2.5
 
 			 -- update all hud elements
 			 update_hud(player)
-			
+
 			 if HUD_ENABLE_HUNGER then
 				local controls = player:get_player_control()
 				-- Determine if the player is walking
@@ -331,7 +331,7 @@ minetest.after(10, function() --originally 2.5
 			 end
 			end
 		 end
-		
+
 		end
 		if timer > 10 then timer = 0 end
 		if timer2 > HUD_HUNGER_TICK then timer2 = 0 end

--- a/mods/inventory_plus/init.lua
+++ b/mods/inventory_plus/init.lua
@@ -28,7 +28,7 @@ inventory_plus.plusplus = true
 inventory_plus.buttons = {}
 
 -- default inventory page
-inventory_plus.default = minetest.settings.get("inventory_default") or "main"
+inventory_plus.default = minetest.settings:get("inventory_default") or "main"
 
 -- original inventory formspec, per player
 inventory_plus.inventory = {}
@@ -61,7 +61,7 @@ end
 
 -- set_inventory_formspec
 inventory_plus.set_inventory_formspec = function(player,formspec)
-	if minetest.settings.get_bool("creative_mode") then
+	if minetest.settings:get_bool("creative_mode") then
 		-- if creative mode is on then wait a bit
 		minetest.after(0.01,function()
 			player:set_inventory_formspec(formspec)
@@ -91,7 +91,7 @@ inventory_plus.get_formspec = function(player,page)
 	end
 	-- craft page
 	if page=="main" then
-		if minetest.settings.get_bool("creative_mode") then
+		if minetest.settings:get_bool("creative_mode") then
 			return player:get_inventory_formspec()
 				.. get_buttons(6,0,2)
 		else
@@ -116,7 +116,7 @@ end)
 minetest.register_on_player_receive_fields(function(player, formname, fields)
 	-- main
 	if fields.main then
-		if minetest.settings.get_bool("creative_mode") then
+		if minetest.settings:get_bool("creative_mode") then
 			minetest.after(0.01,function()
 				inventory_plus.set_inventory_formspec(player, inventory_plus.get_formspec(player,"main"))
 			end)

--- a/mods/irc/config.lua
+++ b/mods/irc/config.lua
@@ -6,7 +6,7 @@ irc.config = {}
 
 local function setting(stype, name, default, required)
 	local value
-	if minetest.settings and minetest.settings.get and minetest.settings.get_bool then
+	if minetest.settings and minetest.settings:get and minetest.settings:get_bool then
 		-- The current methods for getting settings
 		if stype == "bool" then
 			value = minetest.settings:get_bool("irc."..name)
@@ -18,11 +18,11 @@ local function setting(stype, name, default, required)
 	else
 		-- The old methods for getting settings for backward compatibility. Deprecated on 0.4.16+
 		if stype == "bool" then
-			value = minetest.settings.get_bool("irc."..name)
+			value = minetest.settings:get_bool("irc."..name)
 		elseif stype == "string" then
-			value = minetest.settings.get("irc."..name)
+			value = minetest.settings:get("irc."..name)
 		elseif stype == "number" then
-			value = tonumber(minetest.settings.get("irc."..name))
+			value = tonumber(minetest.settings:get("irc."..name))
 		end
 	end
 	if value == nil then

--- a/mods/memorandum/init.lua
+++ b/mods/memorandum/init.lua
@@ -7,7 +7,7 @@ local mname     = "memorandum"
 local sheet =   { -1/2  , -1/2   , -1/2   , 1/2    , -7/16  ,  1/2  }
 local info  =   '"'
 local sign  =   '" Signed by '
-            
+
 minetest.register_craftitem(":default:paper", {
     description = "Paper",
     inventory_image = "default_paper.png",
@@ -36,7 +36,7 @@ minetest.register_node("memorandum:letter_empty", {
     on_construct = function(pos)
         local meta = minetest.get_meta(pos)
         meta:set_string(
-                    "formspec", 
+                    "formspec",
                     "size[10,7]"..
                     "field[1,1;8.5,1;text; Write a Letter;${text}]"..
                     "field[1,3;4.25,1;signed; Sign Letter (optional);${signed}]"..
@@ -216,14 +216,14 @@ minetest.register_tool("memorandum:eraser", {
             if string.find(node.name, "memorandum:letter_written") then
                 if signer == player or signer == "" then
                     meta:set_string(
-                        "formspec", 
+                        "formspec",
                         "size[10,7]"..
                         "field[1,1;8.5,1;text; Edit Text;${text}]"..
                         "field[1,3;4.25,1;signed; Edit Signature;${signed}]"..
                         "button_exit[0.75,5;4.25,1;text,signed;Done]"
                     )
-                    if not minetest.settings.get_bool("creative_mode") then
-                        return eraser_wear(itemstack, user, pointed_thing, 30)  
+                    if not minetest.settings:get_bool("creative_mode") then
+                        return eraser_wear(itemstack, user, pointed_thing, 30)
                     else
                         return {name="memorandum:eraser", count=1, wear=0, metadata=""}
                     end

--- a/mods/mesecons-master/mesecons/settings.lua
+++ b/mods/mesecons-master/mesecons/settings.lua
@@ -1,15 +1,15 @@
 -- SETTINGS
 function mesecon.setting(setting, default)
 	if type(default) == "boolean" then
-		local read = minetest.settings.get_bool("mesecon."..setting)
+		local read = minetest.settings:get_bool("mesecon."..setting)
 		if read == nil then
 			return default
 		else
 			return read
 		end
 	elseif type(default) == "string" then
-		return minetest.settings.get("mesecon."..setting) or default
+		return minetest.settings:get("mesecon."..setting) or default
 	elseif type(default) == "number" then
-		return tonumber(minetest.settings.get("mesecon."..setting) or default)
+		return tonumber(minetest.settings:get("mesecon."..setting) or default)
 	end
 end

--- a/mods/mesecons-master/mesecons_mvps/init.lua
+++ b/mods/mesecons-master/mesecons_mvps/init.lua
@@ -215,7 +215,7 @@ function mesecon.mvps_move_objects(pos, dir, nodestack)
 	end
 
 	-- Move objects lying/standing on the stack (before it was pushed - oldstack)
-	if tonumber(minetest.settings.get("movement_gravity")) > 0 and dir.y == 0 then
+	if tonumber(minetest.settings:get("movement_gravity")) > 0 and dir.y == 0 then
 		-- If gravity positive and dir horizontal, push players standing on the stack
 		for _, n in ipairs(nodestack) do
 			local p_above = vector.add(n.pos, {x=0, y=1, z=0})

--- a/mods/names_per_ip/init.lua
+++ b/mods/names_per_ip/init.lua
@@ -12,7 +12,7 @@ ipnames.save_interval = 120
 ipnames.save_time = 0
 ipnames.file = minetest.get_worldpath().."/ipnames.txt"
 
-ipnames.name_per_ip_limit = tonumber(minetest.settings.get("max_names_per_ip")) or 5
+ipnames.name_per_ip_limit = tonumber(minetest.settings:get("max_names_per_ip")) or 5
 
 -- Get accounts self:
 minetest.register_chatcommand("whois", {
@@ -23,7 +23,7 @@ minetest.register_chatcommand("whois", {
 			minetest.chat_send_player(name, "The player \"" .. param .. "\" did not join yet.")
 			return
 		end
-		
+
 		local ip = ipnames.data[param]
 		local names = "";
 		for k, v in pairs(ipnames.data) do
@@ -48,7 +48,7 @@ minetest.register_chatcommand("alias", {
 			minetest.chat_send_player(name, "The player \"" .. param .. "\" did not join yet.")
 			return
 		end
-		
+
 		local ip = ipnames.data[param]
 		local names = "";
 		for k, v in pairs(ipnames.data) do
@@ -77,11 +77,11 @@ minetest.register_on_prejoinplayer(function(name, ip)
 				names = names .. k .. ", "
 			end
 		end
-		
+
 		if count <= ipnames.name_per_ip_limit and count > 1 then
 			minetest.log("action", name .. " now has " .. count .. " accounts. Other accounts: " .. names)
 		end
-		
+
 		if count > ipnames.name_per_ip_limit then
 			ipnames.tmp_data[name] = nil
 			if tostring(ip) ~= "127.0.0.1" then

--- a/mods/playertools/init.lua
+++ b/mods/playertools/init.lua
@@ -61,7 +61,7 @@ minetest.register_chatcommand("sethp", {
 	description = "Sets your health to <hp> HP (=hearts/2).",
 	privs = {heal=true},
 	func = function(name, hp)
-		if(minetest.settings.get_bool("enable_damage")==true) then
+		if(minetest.settings:get_bool("enable_damage")==true) then
 			local player = minetest.get_player_by_name(name)
 			if not player then
 				return
@@ -87,7 +87,7 @@ minetest.register_chatcommand("sethealth", {
 	description = "Sets your health to <hearts> hearts.",
 	privs = {heal=true},
 	func = function(name, hearts)
-		if(minetest.settings.get_bool("enable_damage")==true) then
+		if(minetest.settings:get_bool("enable_damage")==true) then
 			local player = minetest.get_player_by_name(name)
 			if not player then
 				return
@@ -114,7 +114,7 @@ minetest.register_chatcommand("killme", {
 	params = "",
 	description = "Kills yourself.",
 	func = function(name, param)
-		if(minetest.settings.get_bool("enable_damage")==true) then
+		if(minetest.settings:get_bool("enable_damage")==true) then
 			local player = minetest.get_player_by_name(name)
 			if not player then
 				return
@@ -213,7 +213,7 @@ minetest.register_chatcommand("grief_check", {
 			.. " hours = 24 = 1d, limit = 5",
 	privs = {interact=true},
 	func = function(name, param)
-		if not minetest.settings.get_bool("enable_rollback_recording") then
+		if not minetest.settings:get_bool("enable_rollback_recording") then
 			return false, "Rollback functions are disabled."
 		end
 		local range, hours, limit =
@@ -234,7 +234,7 @@ minetest.register_chatcommand("grief_check", {
 		minetest.rollback_punch_callbacks[name] = function(pos, node, puncher)
 			local name = puncher:get_player_name()
 			minetest.chat_send_player(name, "Checking " .. minetest.pos_to_string(pos) .. "...")
-			local actions = minetest.rollback_get_node_actions(pos, range, seconds, limit)			
+			local actions = minetest.rollback_get_node_actions(pos, range, seconds, limit)
 			if not actions then
 				minetest.chat_send_player(name, "Rollback functions are disabled")
 				return

--- a/mods/protector/doors_chest.lua
+++ b/mods/protector/doors_chest.lua
@@ -71,7 +71,7 @@ function register_door(name, def)
 				minetest.get_meta(pt2):set_int("right", 1)
 			end
 
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:take_item()
 			end
 			return itemstack
@@ -455,9 +455,9 @@ minetest.register_craft({
 minetest.register_craft({
 	output = "protector:trapdoor 2",
         type = "shapeless",
-	recipe = 
+	recipe =
 		{"doors:trapdoor", "default:bronze_ingot", "doors:trapdoor"}
-	
+
 })
 
 -- Protected Steel Trapdoor
@@ -609,7 +609,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 					end
 				end
 			end
-	
+
 		elseif fields.todn then
 
 			-- copy contents of chest to players inventory

--- a/mods/protector/init.lua
+++ b/mods/protector/init.lua
@@ -2,9 +2,9 @@ minetest.register_privilege("delprotect","Ignore player protection")
 
 protector = {}
 protector.mod = "redo"
-protector.radius = (tonumber(minetest.settings.get("protector_radius")) or 5)
-protector.drop = minetest.settings.get_bool("protector_drop") or false
-protector.hurt = (tonumber(minetest.settings.get("protector_hurt")) or 0)
+protector.radius = (tonumber(minetest.settings:get("protector_radius")) or 5)
+protector.drop = minetest.settings:get_bool("protector_drop") or false
+protector.hurt = (tonumber(minetest.settings:get("protector_hurt")) or 0)
 
 protector.get_member_list = function(meta)
 
@@ -90,7 +90,7 @@ protector.generate_formspec = function(meta)
 
 		i = i + 1
 	end
-	
+
 	if i < npp then
 
 		-- user name entry field
@@ -144,7 +144,7 @@ protector.can_dig = function(r, pos, digger, onlyowner, infolevel)
 		owner = meta:get_string("owner")
 		members = meta:get_string("members")
 
-		if owner ~= digger then 
+		if owner ~= digger then
 
 			if onlyowner
 			or not protector.is_member(meta, digger) then
@@ -324,7 +324,7 @@ minetest.register_node("protector:protect", {
 
 		if meta
 		and protector.can_dig(1, pos,clicker:get_player_name(), true, 1) then
-			minetest.show_formspec(clicker:get_player_name(), 
+			minetest.show_formspec(clicker:get_player_name(),
 			"protector:node_" .. minetest.pos_to_string(pos), protector.generate_formspec(meta))
 		end
 	end,
@@ -405,7 +405,7 @@ minetest.register_node("protector:protect2", {
 
 		if protector.can_dig(1, pos, clicker:get_player_name(), true, 1) then
 
-			minetest.show_formspec(clicker:get_player_name(), 
+			minetest.show_formspec(clicker:get_player_name(),
 			"protector:node_" .. minetest.pos_to_string(pos), protector.generate_formspec(meta))
 		end
 	end,
@@ -463,7 +463,7 @@ minetest.register_on_player_receive_fields(function(player, formname, fields)
 				protector.del_member(meta, string.sub(field,string.len("protector_del_member_") + 1))
 			end
 		end
-		
+
 		if not fields.close_me then
 			minetest.show_formspec(player:get_player_name(), formname, protector.generate_formspec(meta))
 		end

--- a/mods/protector/pvp.lua
+++ b/mods/protector/pvp.lua
@@ -3,11 +3,11 @@
 local statspawn = (minetest.setting_get_pos("static_spawnpoint") or {x = 0, y = 2, z = 0})
 
 -- is pvp protection enabled and spawn protected
-protector.pvp = minetest.settings.get_bool("protector_pvp")
-protector.spawn = (tonumber(minetest.settings.get("protector_pvp_spawn")) or 0)
+protector.pvp = minetest.settings:get_bool("protector_pvp")
+protector.spawn = (tonumber(minetest.settings:get("protector_pvp_spawn")) or 0)
 
 -- Disable PVP in your own protected areas
-if minetest.settings.get_bool("enable_pvp") and protector.pvp then
+if minetest.settings:get_bool("enable_pvp") and protector.pvp then
 
 	if minetest.register_on_punchplayer then
 

--- a/mods/real_suffocation/init.lua
+++ b/mods/real_suffocation/init.lua
@@ -1,6 +1,6 @@
 -- Load setting
 local suffocation_damage = 10
-local setting = minetest.settings.get("real_suffocation_damage")
+local setting = minetest.settings:get("real_suffocation_damage")
 if tonumber(setting) ~= nil then
 	suffocation_damage = tonumber(setting)
 end
@@ -24,7 +24,7 @@ function add_suffocation()
 			Everything else is probably too small for suffocation to seem real.
 		- disable_suffocation group: If set to 1, we bail out. This makes it possible for nodes to defend themselves against hacking. :-)
 		]]
-		if (def.walkable == nil or def.walkable == true) 
+		if (def.walkable == nil or def.walkable == true)
 		and (def.drowning == nil or def.drowning == 0)
 		and (def.damage_per_second == nil or def.damage_per_second <= 0)
 		and (def.collision_box == nil or def.collision_box.type == "regular")

--- a/mods/report/init.lua
+++ b/mods/report/init.lua
@@ -24,12 +24,12 @@ minetest.register_chatcommand("report", {
 
 		if #mods > 0 then
 			mod_list = table.concat(mods, ", ")
-			email.send_mail(name, minetest.settings.get("name"),
+			email.send_mail(name, minetest.settings:get("name"),
 				"Report: " .. param .. " (mods online: " .. mod_list .. ")")
                                 irc:say(name .. " sent a report! (mods online: " .. mod_list .. ")")
 			return true, "Reported. Moderators currently online: " .. mod_list
 		else
-			email.send_mail(name, minetest.settings.get("name"),
+			email.send_mail(name, minetest.settings:get("name"),
 				"Report: " .. param .. " (no mods online)")
                                 irc:say(name .. " sent a report! (no mods online)")
 			return true, "Reported. We'll get back to you."

--- a/mods/screwdriver/init.lua
+++ b/mods/screwdriver/init.lua
@@ -81,7 +81,7 @@ local function screwdriver_handler(itemstack, user, pointed_thing, mode)
 		minetest.swap_node(pos, node)
 	end
 
-	if not minetest.settings.get_bool("creative_mode") then
+	if not minetest.settings:get_bool("creative_mode") then
 		itemstack:add_wear(65535 / (USES - 1))
 	end
 

--- a/mods/shooter/bow.lua
+++ b/mods/shooter/bow.lua
@@ -177,7 +177,7 @@ for _, color in pairs(dye_basecolors) do
 		groups = {not_in_creative_inventory=1},
 		on_use = function(itemstack, user, pointed_thing)
 			minetest.sound_play("shooter_click", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:add_wear(65535/SHOOTER_CROSSBOW_USES)
 			end
 			itemstack = "shooter:bow 1 "..itemstack:get_wear()
@@ -196,7 +196,7 @@ for _, color in pairs(dye_basecolors) do
 					obj:set_properties({
 						textures = {get_texture("arrow_uv", color)}
 					})
-					minetest.sound_play("shooter_throw", {object=obj}) 
+					minetest.sound_play("shooter_throw", {object=obj})
 					local frame = get_animation_frame(dir)
 					obj:setyaw(yaw + math.pi)
 					obj:set_animation({x=frame, y=frame}, 0)
@@ -241,7 +241,7 @@ minetest.register_tool("shooter:bow", {
 		local color = string.match(stack:get_name(), "shooter:arrow_(%a+)")
 		if color then
 			minetest.sound_play("shooter_reload", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				inv:remove_item("main", "shooter:arrow_"..color.." 1")
 			end
 			return "shooter:bow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -249,7 +249,7 @@ minetest.register_tool("shooter:bow", {
 		for _, color in pairs(dye_basecolors) do
 			if inv:contains_item("main", "shooter:arrow_"..color) then
 				minetest.sound_play("shooter_reload", {object=user})
-				if not minetest.settings.get_bool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					inv:remove_item("main", "shooter:arrow_"..color.." 1")
 				end
 				return "shooter:bow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -286,4 +286,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		end
 	end
 end
-

--- a/mods/shooter/crossbow.lua
+++ b/mods/shooter/crossbow.lua
@@ -177,7 +177,7 @@ for _, color in pairs(dye_basecolors) do
 		groups = {not_in_creative_inventory=1},
 		on_use = function(itemstack, user, pointed_thing)
 			minetest.sound_play("shooter_click", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:add_wear(65535/SHOOTER_CROSSBOW_USES)
 			end
 			itemstack = "shooter:crossbow 1 "..itemstack:get_wear()
@@ -196,7 +196,7 @@ for _, color in pairs(dye_basecolors) do
 					obj:set_properties({
 						textures = {get_texture("arrow_uv", color)}
 					})
-					minetest.sound_play("shooter_throw", {object=obj}) 
+					minetest.sound_play("shooter_throw", {object=obj})
 					local frame = get_animation_frame(dir)
 					obj:setyaw(yaw + math.pi)
 					obj:set_animation({x=frame, y=frame}, 0)
@@ -247,7 +247,7 @@ minetest.register_tool("shooter:crossbow", {
 		local color = string.match(stack:get_name(), "shooter:arrow_(%a+)")
 		if color then
 			minetest.sound_play("shooter_reload", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				inv:remove_item("main", "shooter:arrow_"..color.." 1")
 			end
 			return "shooter:crossbow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -255,7 +255,7 @@ minetest.register_tool("shooter:crossbow", {
 		for _, color in pairs(dye_basecolors) do
 			if inv:contains_item("main", "shooter:arrow_"..color) then
 				minetest.sound_play("shooter_reload", {object=user})
-				if not minetest.settings.get_bool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					inv:remove_item("main", "shooter:arrow_"..color.." 1")
 				end
 				return "shooter:crossbow_loaded_"..color.." 1 "..itemstack:get_wear()

--- a/mods/shooter/crossbow_orig.lua
+++ b/mods/shooter/crossbow_orig.lua
@@ -177,7 +177,7 @@ for _, color in pairs(dye_basecolors) do
 		groups = {not_in_creative_inventory=1},
 		on_use = function(itemstack, user, pointed_thing)
 			minetest.sound_play("shooter_click", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:add_wear(65535/SHOOTER_CROSSBOW_USES)
 			end
 			itemstack = "shooter:crossbow 1 "..itemstack:get_wear()
@@ -196,7 +196,7 @@ for _, color in pairs(dye_basecolors) do
 					obj:set_properties({
 						textures = {get_texture("arrow_uv", color)}
 					})
-					minetest.sound_play("shooter_throw", {object=obj}) 
+					minetest.sound_play("shooter_throw", {object=obj})
 					local frame = get_animation_frame(dir)
 					obj:setyaw(yaw + math.pi)
 					obj:set_animation({x=frame, y=frame}, 0)
@@ -241,7 +241,7 @@ minetest.register_tool("shooter:crossbow", {
 		local color = string.match(stack:get_name(), "shooter:arrow_(%a+)")
 		if color then
 			minetest.sound_play("shooter_reload", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				inv:remove_item("main", "shooter:arrow_"..color.." 1")
 			end
 			return "shooter:crossbow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -249,7 +249,7 @@ minetest.register_tool("shooter:crossbow", {
 		for _, color in pairs(dye_basecolors) do
 			if inv:contains_item("main", "shooter:arrow_"..color) then
 				minetest.sound_play("shooter_reload", {object=user})
-				if not minetest.settings.get_bool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					inv:remove_item("main", "shooter:arrow_"..color.." 1")
 				end
 				return "shooter:crossbow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -287,4 +287,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		end
 	end
 end
-

--- a/mods/shooter/flaregun.lua
+++ b/mods/shooter/flaregun.lua
@@ -104,7 +104,7 @@ minetest.register_tool("shooter:flaregun", {
 			minetest.sound_play("shooter_click", {object=user})
 			return itemstack
 		end
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			inv:remove_item("main", "shooter:flare 1")
 			itemstack:add_wear(65535/100)
 		end
@@ -144,4 +144,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		},
 	})
 end
-

--- a/mods/shooter/grapple.lua
+++ b/mods/shooter/grapple.lua
@@ -4,7 +4,7 @@ local function throw_hook(itemstack, user, vel)
 	local dir = user:get_look_dir()
 	local yaw = user:get_look_yaw()
 	if pos and dir and yaw then
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			itemstack:add_wear(65535/100)
 		end
 		pos.y = pos.y + 1.5
@@ -84,7 +84,7 @@ minetest.register_tool("shooter:grapple_gun", {
 	inventory_image = "shooter_hook_gun.png",
 	on_use = function(itemstack, user, pointed_thing)
 		local inv = user:get_inventory()
-		if inv:contains_item("main", "shooter:grapple_hook") and 
+		if inv:contains_item("main", "shooter:grapple_hook") and
 				inv:contains_item("main", "tnt:gunpowder") then
 			inv:remove_item("main", "tnt:gunpowder")
 			minetest.sound_play("shooter_reload", {object=user})

--- a/mods/shooter/grenade.lua
+++ b/mods/shooter/grenade.lua
@@ -39,7 +39,7 @@ minetest.register_tool("shooter:grenade", {
 	description = "Grenade",
 	inventory_image = "shooter_hand_grenade.png",
 	on_use = function(itemstack, user, pointed_thing)
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			itemstack = ""
 		end
 		if pointed_thing.type ~= "nothing" then
@@ -77,4 +77,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		},
 	})
 end
-

--- a/mods/shooter/rocket.lua
+++ b/mods/shooter/rocket.lua
@@ -45,7 +45,7 @@ minetest.register_tool("shooter:rocket_gun_loaded", {
 	inventory_image = "shooter_rocket_gun_loaded.png",
 	groups = {not_in_creative_inventory=1},
 	on_use = function(itemstack, user, pointed_thing)
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			itemstack:add_wear(65535/50)
 		end
 		itemstack = "shooter:rocket_gun 1 "..itemstack:get_wear()
@@ -84,7 +84,7 @@ minetest.register_tool("shooter:rocket_gun", {
 		local inv = user:get_inventory()
 		if inv:contains_item("main", "shooter:rocket") then
 			minetest.sound_play("shooter_reload", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				inv:remove_item("main", "shooter:rocket 1")
 			end
 			itemstack = "shooter:rocket_gun_loaded 1 "..itemstack:get_wear()
@@ -110,4 +110,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		},
 	})
 end
-

--- a/mods/shooter/smoke.lua
+++ b/mods/shooter/smoke.lua
@@ -52,7 +52,7 @@ minetest.register_tool("shooter:smoke", {
 	description = "Smoke Grenade",
 	inventory_image = "shooter_smoke_grenade.png",
 	on_use = function(itemstack, user, pointed_thing)
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			itemstack = ""
 		end
 		if pointed_thing.type ~= "nothing" then
@@ -90,4 +90,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		},
 	})
 end
-

--- a/mods/shooter/turret.lua
+++ b/mods/shooter/turret.lua
@@ -50,7 +50,7 @@ minetest.register_entity("shooter:tnt_entity", {
 	end,
 	get_staticdata = function(self)
 		return "expired"
-	end,	
+	end,
 })
 
 minetest.register_entity("shooter:turret_entity", {
@@ -102,7 +102,7 @@ minetest.register_entity("shooter:turret_entity", {
 		self.timer = self.timer + dtime
 		if self.timer < 0.1 then
 			return
-		end	
+		end
 		if self.player then
 			local pitch = self.pitch
 			local yaw = self.object:getyaw()
@@ -132,7 +132,7 @@ minetest.register_entity("shooter:turret_entity", {
 				end
 				if pitch < 0 then
 					pitch = 0
-				elseif pitch > 90 then 
+				elseif pitch > 90 then
 					pitch = 90
 				end
 				if self.pitch ~= pitch then
@@ -158,7 +158,7 @@ minetest.register_entity("shooter:turret_entity", {
 			return
 		end
 		minetest.sound_play("shooter_shotgun", {object=self.object})
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			inv:remove_item("main", "tnt:tnt")
 		end
 		local pitch = math.rad(self.pitch - 40)
@@ -273,4 +273,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		},
 	})
 end
-

--- a/mods/signs/init.lua
+++ b/mods/signs/init.lua
@@ -63,7 +63,7 @@ local update_sign = function(pos, fields)
 			return
         end
     end
-	
+
 	-- if there is no entity
 	local sign_info
 	if minetest.env:get_node(pos).name == "signs:sign_yard" then
@@ -97,13 +97,13 @@ minetest.register_node(":default:sign_wall_wood", {
     on_place = function(itemstack, placer, pointed_thing)
         local above = pointed_thing.above
         local under = pointed_thing.under
-			
+
 	pname = placer:get_player_name()
 	if minetest.is_protected(above, pname) then
 		minetest.record_protection_violation(above, pname)
 		return itemstack
 	end
-			
+
         local dir = {x = under.x - above.x,
                      y = under.y - above.y,
                      z = under.z - above.z}
@@ -122,9 +122,9 @@ minetest.register_node(":default:sign_wall_wood", {
         local fdir = minetest.dir_to_facedir(dir)
 
         local sign_info
-		
+
 		if minetest.env:get_node(above).name == "air" then
-		
+
         if wdir == 0 then
             --how would you add sign to ceiling?
             minetest.env:add_item(above, "default:sign_wall_wood")
@@ -308,6 +308,6 @@ end
 modpath=minetest.get_modpath("signs")
 
 dofile(modpath.."/steelsign.lua")
-if minetest.settings.get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "signs loaded")
 end

--- a/mods/signs/shooter/bow.lua
+++ b/mods/signs/shooter/bow.lua
@@ -177,7 +177,7 @@ for _, color in pairs(dye_basecolors) do
 		groups = {not_in_creative_inventory=1},
 		on_use = function(itemstack, user, pointed_thing)
 			minetest.sound_play("shooter_click", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:add_wear(65535/SHOOTER_CROSSBOW_USES)
 			end
 			itemstack = "shooter:bow 1 "..itemstack:get_wear()
@@ -196,7 +196,7 @@ for _, color in pairs(dye_basecolors) do
 					obj:set_properties({
 						textures = {get_texture("arrow_uv", color)}
 					})
-					minetest.sound_play("shooter_throw", {object=obj}) 
+					minetest.sound_play("shooter_throw", {object=obj})
 					local frame = get_animation_frame(dir)
 					obj:setyaw(yaw + math.pi)
 					obj:set_animation({x=frame, y=frame}, 0)
@@ -241,7 +241,7 @@ minetest.register_tool("shooter:bow", {
 		local color = string.match(stack:get_name(), "shooter:arrow_(%a+)")
 		if color then
 			minetest.sound_play("shooter_reload", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				inv:remove_item("main", "shooter:arrow_"..color.." 1")
 			end
 			return "shooter:bow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -249,7 +249,7 @@ minetest.register_tool("shooter:bow", {
 		for _, color in pairs(dye_basecolors) do
 			if inv:contains_item("main", "shooter:arrow_"..color) then
 				minetest.sound_play("shooter_reload", {object=user})
-				if not minetest.settings.get_bool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					inv:remove_item("main", "shooter:arrow_"..color.." 1")
 				end
 				return "shooter:bow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -286,4 +286,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		end
 	end
 end
-

--- a/mods/signs/shooter/crossbow.lua
+++ b/mods/signs/shooter/crossbow.lua
@@ -177,7 +177,7 @@ for _, color in pairs(dye_basecolors) do
 		groups = {not_in_creative_inventory=1},
 		on_use = function(itemstack, user, pointed_thing)
 			minetest.sound_play("shooter_click", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:add_wear(65535/SHOOTER_CROSSBOW_USES)
 			end
 			itemstack = "shooter:crossbow 1 "..itemstack:get_wear()
@@ -196,7 +196,7 @@ for _, color in pairs(dye_basecolors) do
 					obj:set_properties({
 						textures = {get_texture("arrow_uv", color)}
 					})
-					minetest.sound_play("shooter_throw", {object=obj}) 
+					minetest.sound_play("shooter_throw", {object=obj})
 					local frame = get_animation_frame(dir)
 					obj:setyaw(yaw + math.pi)
 					obj:set_animation({x=frame, y=frame}, 0)
@@ -247,7 +247,7 @@ minetest.register_tool("shooter:crossbow", {
 		local color = string.match(stack:get_name(), "shooter:arrow_(%a+)")
 		if color then
 			minetest.sound_play("shooter_reload", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				inv:remove_item("main", "shooter:arrow_"..color.." 1")
 			end
 			return "shooter:crossbow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -255,7 +255,7 @@ minetest.register_tool("shooter:crossbow", {
 		for _, color in pairs(dye_basecolors) do
 			if inv:contains_item("main", "shooter:arrow_"..color) then
 				minetest.sound_play("shooter_reload", {object=user})
-				if not minetest.settings.get_bool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					inv:remove_item("main", "shooter:arrow_"..color.." 1")
 				end
 				return "shooter:crossbow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -321,4 +321,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		end
 	end
 end
-

--- a/mods/signs/shooter/crossbow_orig.lua
+++ b/mods/signs/shooter/crossbow_orig.lua
@@ -177,7 +177,7 @@ for _, color in pairs(dye_basecolors) do
 		groups = {not_in_creative_inventory=1},
 		on_use = function(itemstack, user, pointed_thing)
 			minetest.sound_play("shooter_click", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:add_wear(65535/SHOOTER_CROSSBOW_USES)
 			end
 			itemstack = "shooter:crossbow 1 "..itemstack:get_wear()
@@ -196,7 +196,7 @@ for _, color in pairs(dye_basecolors) do
 					obj:set_properties({
 						textures = {get_texture("arrow_uv", color)}
 					})
-					minetest.sound_play("shooter_throw", {object=obj}) 
+					minetest.sound_play("shooter_throw", {object=obj})
 					local frame = get_animation_frame(dir)
 					obj:setyaw(yaw + math.pi)
 					obj:set_animation({x=frame, y=frame}, 0)
@@ -241,7 +241,7 @@ minetest.register_tool("shooter:crossbow", {
 		local color = string.match(stack:get_name(), "shooter:arrow_(%a+)")
 		if color then
 			minetest.sound_play("shooter_reload", {object=user})
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				inv:remove_item("main", "shooter:arrow_"..color.." 1")
 			end
 			return "shooter:crossbow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -249,7 +249,7 @@ minetest.register_tool("shooter:crossbow", {
 		for _, color in pairs(dye_basecolors) do
 			if inv:contains_item("main", "shooter:arrow_"..color) then
 				minetest.sound_play("shooter_reload", {object=user})
-				if not minetest.settings.get_bool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					inv:remove_item("main", "shooter:arrow_"..color.." 1")
 				end
 				return "shooter:crossbow_loaded_"..color.." 1 "..itemstack:get_wear()
@@ -287,4 +287,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		end
 	end
 end
-

--- a/mods/signs/shooter/flaregun.lua
+++ b/mods/signs/shooter/flaregun.lua
@@ -104,7 +104,7 @@ minetest.register_tool("shooter:flaregun", {
 			minetest.sound_play("shooter_click", {object=user})
 			return itemstack
 		end
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			inv:remove_item("main", "shooter:flare 1")
 			itemstack:add_wear(65535/100)
 		end
@@ -144,4 +144,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		},
 	})
 end
-

--- a/mods/signs/shooter/grapple.lua
+++ b/mods/signs/shooter/grapple.lua
@@ -4,7 +4,7 @@ local function throw_hook(itemstack, user, vel)
 	local dir = user:get_look_dir()
 	local yaw = user:get_look_yaw()
 	if pos and dir and yaw then
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			itemstack:add_wear(65535/100)
 		end
 		pos.y = pos.y + 1.5
@@ -84,7 +84,7 @@ minetest.register_tool("shooter:grapple_gun", {
 	inventory_image = "shooter_hook_gun.png",
 	on_use = function(itemstack, user, pointed_thing)
 		local inv = user:get_inventory()
-		if inv:contains_item("main", "shooter:grapple_hook") and 
+		if inv:contains_item("main", "shooter:grapple_hook") and
 				inv:contains_item("main", "tnt:gunpowder") then
 			inv:remove_item("main", "tnt:gunpowder")
 			minetest.sound_play("shooter_reload", {object=user})

--- a/mods/signs/shooter/grenade.lua
+++ b/mods/signs/shooter/grenade.lua
@@ -39,7 +39,7 @@ minetest.register_tool("shooter:grenade", {
 	description = "Grenade",
 	inventory_image = "shooter_hand_grenade.png",
 	on_use = function(itemstack, user, pointed_thing)
-		if not minetest.settings.get_bool("creative_mode") then
+		if not minetest.settings:get_bool("creative_mode") then
 			itemstack = ""
 		end
 		if pointed_thing.type ~= "nothing" then
@@ -77,4 +77,3 @@ if SHOOTER_ENABLE_CRAFTING == true then
 		},
 	})
 end
-

--- a/mods/signs/steelsign.lua
+++ b/mods/signs/steelsign.lua
@@ -62,7 +62,7 @@ local update_sign = function(pos, fields)
 			return
         end
     end
-	
+
 	-- if there is no entity
 	local sign_info
 	if minetest.env:get_node(pos).name == "signs:sign_yard_steel" then
@@ -96,13 +96,13 @@ minetest.register_node(":default:sign_wall_steel", {
     on_place = function(itemstack, placer, pointed_thing)
         local above = pointed_thing.above
         local under = pointed_thing.under
-			
+
 	pname = placer:get_player_name()
 	if minetest.is_protected(above, pname) then
 		minetest.record_protection_violation(above, pname)
 		return itemstack
 	end
-		
+
         local dir = {x = under.x - above.x,
                      y = under.y - above.y,
                      z = under.z - above.z}
@@ -121,9 +121,9 @@ minetest.register_node(":default:sign_wall_steel", {
         local fdir = minetest.dir_to_facedir(dir)
 
         local sign_info
-		
+
 		if minetest.env:get_node(above).name == "air" then
-		
+
         if wdir == 0 then
             --how would you add sign to ceiling?
             minetest.env:add_item(above, "default:sign_wall_steel")
@@ -141,12 +141,12 @@ minetest.register_node(":default:sign_wall_steel", {
                                               y = above.y + sign_info.delta.y,
                                               z = above.z + sign_info.delta.z}, "signs:text")
         text:setyaw(sign_info.yaw)
-		
+
 		local meta = minetest.get_meta(above)
 		local owner = placer:get_player_name()
 		meta:set_string("owner", owner)
 		meta:set_string("infotext", ("Locked sign (Owned by "..owner..")"))
-		
+
 		itemstack:take_item()
         return itemstack
 		end
@@ -165,14 +165,14 @@ minetest.register_node(":default:sign_wall_steel", {
     on_receive_fields = function(pos, formname, fields, sender)
 		local meta = minetest.get_meta(pos);
 		local owner = meta:get_string("owner")
-		if sender:get_player_name() == owner or owner == "" then		
+		if sender:get_player_name() == owner or owner == "" then
 			update_sign(pos, fields)
 		end
     end,
 	on_punch = function(pos, node, puncher)
 		local meta = minetest.get_meta(pos);
 		local owner = meta:get_string("owner")
-		if puncher:get_player_name() == owner or owner == "" then		
+		if puncher:get_player_name() == owner or owner == "" then
 			update_sign(pos, fields)
 		end
 	end,
@@ -205,14 +205,14 @@ minetest.register_node("signs:sign_yard_steel", {
     on_receive_fields = function(pos, formname, fields, sender)
 		local meta = minetest.get_meta(pos);
 		local owner = meta:get_string("owner")
-		if sender:get_player_name() == owner or owner == "" then		
+		if sender:get_player_name() == owner or owner == "" then
 			update_sign(pos, fields)
 		end
     end,
 	on_punch = function(pos, node, puncher)
 		local meta = minetest.get_meta(pos);
 		local owner = meta:get_string("owner")
-		if puncher:get_player_name() == owner or owner == "" then		
+		if puncher:get_player_name() == owner or owner == "" then
 			update_sign(pos, fields)
 		end
 	end,
@@ -226,6 +226,6 @@ minetest.register_craft({
 	}
 })
 
-if minetest.settings.get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "locked signs loaded")
 end

--- a/mods/stairs/init.lua
+++ b/mods/stairs/init.lua
@@ -15,7 +15,7 @@ minetest.register_alias("stairs:slab_pinewood", "stairs:slab_pine_wood")
 
 -- Get setting for replace ABM
 
-local replace = minetest.settings.get_bool("enable_stairs_replace_abm")
+local replace = minetest.settings:get_bool("enable_stairs_replace_abm")
 
 
 -- Register stairs.
@@ -105,7 +105,7 @@ function stairs.register_stair(subname, recipeitem, groups, images, description,
 			{recipeitem, recipeitem, recipeitem},
 		},
 	})
-        
+
         --added by sparky: less stair recipie
 
 	minetest.register_craft({
@@ -190,7 +190,7 @@ function stairs.register_slab(subname, recipeitem, groups, images, description, 
 				end
 				return itemstack
 			end
-			
+
 			-- Upside down slabs
 			if p0.y - 1 == p1.y then
 				-- Turn into full block if pointing at a existing slab
@@ -369,7 +369,7 @@ stairs.register_stair_and_slab("sandstone", "default:sandstone",
 		"Sandstone Stair",
 		"Sandstone Slab",
 		default.node_sound_stone_defaults())
-		
+
 stairs.register_stair_and_slab("sandstonebrick", "default:sandstonebrick",
 		{crumbly = 2, cracky = 2},
 		{"default_sandstone_brick.png"},

--- a/mods/throwing/build_arrow.lua
+++ b/mods/throwing/build_arrow.lua
@@ -18,7 +18,7 @@ minetest.register_node("throwing:arrow_build_box", {
 			{7.5/17, -2.5/17, 2.5/17, 6.5/17, -1.5/17, 1.5/17},
 			{7.5/17, 2.5/17, -2.5/17, 6.5/17, 1.5/17, -1.5/17},
 			{6.5/17, -1.5/17, -1.5/17, 7.5/17, -2.5/17, -2.5/17},
-			
+
 			{7.5/17, 2.5/17, 2.5/17, 8.5/17, 3.5/17, 3.5/17},
 			{8.5/17, -3.5/17, 3.5/17, 7.5/17, -2.5/17, 2.5/17},
 			{8.5/17, 3.5/17, -3.5/17, 7.5/17, 2.5/17, -2.5/17},
@@ -54,7 +54,7 @@ THROWING_ARROW_ENTITY.on_step = function(self, dtime)
 			if obj:get_luaentity() ~= nil then
 				if obj:get_luaentity().name ~= "throwing:arrow_build_entity" and obj:get_luaentity().name ~= "__builtin:item" then
 					self.object:remove()
-					if self.inventory and self.stack and not minetest.settings.get_bool("creative_mode") then
+					if self.inventory and self.stack and not minetest.settings:get_bool("creative_mode") then
 						self.inventory:remove_item("main", {name=self.stack:get_name()})
 					end
 					if self.stack then
@@ -74,7 +74,7 @@ THROWING_ARROW_ENTITY.on_step = function(self, dtime)
 	if self.lastpos.x~=nil then
 		if node.name ~= "air" then
 			self.object:remove()
-			if self.inventory and self.stack and not minetest.settings.get_bool("creative_mode") then
+			if self.inventory and self.stack and not minetest.settings:get_bool("creative_mode") then
 					self.inventory:remove_item("main", {name=self.stack:get_name()})
 			end
 			if self.stack then

--- a/mods/throwing/functions.lua
+++ b/mods/throwing/functions.lua
@@ -1,6 +1,6 @@
---~ 
+--~
 --~ Shot and reload system
---~ 
+--~
 
 local players = {}
 
@@ -44,7 +44,7 @@ function throwing_unload (itemstack, player, unloaded, wear)
 	if itemstack:get_metadata() then
 		for _,arrow in ipairs(throwing_arrows) do
 			if itemstack:get_metadata() == arrow[2] then
-				if not minetest.settings.get_bool("creative_mode") then
+				if not minetest.settings:get_bool("creative_mode") then
 					player:get_inventory():add_item("main", arrow[1])
 				end
 			end
@@ -65,7 +65,7 @@ function throwing_reload (itemstack, player, pos, is_cross, loaded)
 			local wear = itemstack:get_wear()
 			for _,arrow in ipairs(throwing_arrows) do
 				if player:get_inventory():get_stack("main", player:get_wield_index()+1):get_name() == arrow[1] then
-					if not minetest.settings.get_bool("creative_mode") then
+					if not minetest.settings:get_bool("creative_mode") then
 						player:get_inventory():remove_item("main", arrow[1])
 					end
 					local meta = arrow[2]
@@ -83,7 +83,7 @@ function throwing_register_bow (name, desc, scale, stiffness, reload_time, tough
 		description = desc,
 		inventory_image = "throwing_" .. name .. ".png",
 		wield_scale = scale,
-	    stack_max = 1,	
+	    stack_max = 1,
 		on_use = function(itemstack, user, pointed_thing)
 			local pos = user:getpos()
 			local playerName = user:get_player_name()
@@ -94,7 +94,7 @@ function throwing_register_bow (name, desc, scale, stiffness, reload_time, tough
 			return itemstack
 		end,
 	})
-	
+
 	minetest.register_tool("throwing:" .. name .. "_loaded", {
 		description = desc,
 		inventory_image = "throwing_" .. name .. "_loaded.png",
@@ -102,12 +102,12 @@ function throwing_register_bow (name, desc, scale, stiffness, reload_time, tough
 	    stack_max = 1,
 		on_use = function(itemstack, user, pointed_thing)
 			local wear = itemstack:get_wear()
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				wear = wear + (65535/toughness)
 			end
 			local unloaded = "throwing:" .. name
 			throwing_shoot_arrow(itemstack, user, stiffness, is_cross)
-			minetest.after(0, throwing_unload, itemstack, user, unloaded, wear)				
+			minetest.after(0, throwing_unload, itemstack, user, unloaded, wear)
 			return itemstack
 		end,
 		on_drop = function(itemstack, dropper, pointed_thing)
@@ -117,7 +117,7 @@ function throwing_register_bow (name, desc, scale, stiffness, reload_time, tough
 		end,
 		groups = {not_in_creative_inventory=1},
 	})
-	
+
 	minetest.register_craft({
 		output = 'throwing:' .. name,
 		recipe = craft

--- a/mods/throwing/init.lua
+++ b/mods/throwing/init.lua
@@ -61,6 +61,6 @@ if minetest.get_modpath('tnt') then
 	dofile(minetest.get_modpath("throwing").."/fireworks_arrows.lua")
 end
 
-if minetest.settings.get("log_mods") then
+if minetest.settings:get("log_mods") then
 	minetest.log("action", "throwing loaded")
 end

--- a/mods/throwing/tnt_arrow.lua
+++ b/mods/throwing/tnt_arrow.lua
@@ -18,7 +18,7 @@ minetest.register_node("throwing:arrow_tnt_box", {
 			{7.5/17, -2.5/17, 2.5/17, 6.5/17, -1.5/17, 1.5/17},
 			{7.5/17, 2.5/17, -2.5/17, 6.5/17, 1.5/17, -1.5/17},
 			{6.5/17, -1.5/17, -1.5/17, 7.5/17, -2.5/17, -2.5/17},
-			
+
 			{7.5/17, 2.5/17, 2.5/17, 8.5/17, 3.5/17, 3.5/17},
 			{8.5/17, -3.5/17, 3.5/17, 7.5/17, -2.5/17, 2.5/17},
 			{8.5/17, 3.5/17, -3.5/17, 7.5/17, 2.5/17, -2.5/17},
@@ -47,7 +47,7 @@ local loss_prob = {}
 loss_prob["default:cobble"] = 3
 loss_prob["default:dirt"] = 4
 
-local radius = tonumber(minetest.settings.get("tnt_radius") or 3)
+local radius = tonumber(minetest.settings:get("tnt_radius") or 3)
 
 -- Fill a list with data for content IDs, after all nodes are registered
 local cid_data = {}

--- a/mods/tnt/hud/init.lua
+++ b/mods/tnt/hud/init.lua
@@ -49,7 +49,7 @@ HUD_TICK = 0.1
 --Some hunger settings
 hud.exhaustion = {} -- Exhaustion is experimental!
 
-HUD_HUNGER_TICK = 800 -- time in seconds after that 1 hunger point is taken 
+HUD_HUNGER_TICK = 800 -- time in seconds after that 1 hunger point is taken
 HUD_HUNGER_EXHAUST_DIG = 3  -- exhaustion increased this value after digged node
 HUD_HUNGER_EXHAUST_PLACE = 1 -- exhaustion increased this value after placed
 HUD_HUNGER_EXHAUST_MOVE = 0.3 -- exhaustion increased this value if player movement detected
@@ -57,9 +57,9 @@ HUD_HUNGER_EXHAUST_LVL = 160 -- at what exhaustion player saturation gets lowerd
 
 
 
-HUD_ENABLE_HUNGER = minetest.settings.get_bool("hud_hunger_enable")
+HUD_ENABLE_HUNGER = minetest.settings:get_bool("hud_hunger_enable")
 if HUD_ENABLE_HUNGER == nil then
-	HUD_ENABLE_HUNGER = minetest.settings.get_bool("enable_damage")
+	HUD_ENABLE_HUNGER = minetest.settings:get_bool("enable_damage")
 end
 
 HUD_SHOW_ARMOR = false
@@ -69,7 +69,7 @@ end
 
 --load custom settings
 local set = io.open(minetest.get_modpath("hud").."/hud.conf", "r")
-if set then 
+if set then
 	dofile(minetest.get_modpath("hud").."/hud.conf")
 	set:close()
 else
@@ -92,7 +92,7 @@ local function custom_hud(player)
 	player:hud_set_hotbar_selected_image("hud_hotbar_selected.png")
  end
 
- if minetest.settings.get_bool("enable_damage") then
+ if minetest.settings:get_bool("enable_damage") then
  --hunger
 	if HUD_ENABLE_HUNGER then
        	 player:hud_add({
@@ -243,7 +243,7 @@ hud.set_hunger = function(player)
 	if not inv  or not value then return nil end
 	if value > 30 then value = 30 end
 	if value < 0 then value = 0 end
-	
+
 	inv:set_stack("hunger", 1, ItemStack({name=":", count=value+1}))
 
 	return true
@@ -296,7 +296,7 @@ minetest.after(2.5, function()
 			local name = player:get_player_name()
 
 			-- only proceed if damage is enabled
-			if minetest.settings.get_bool("enable_damage") then
+			if minetest.settings:get_bool("enable_damage") then
 			 local h = tonumber(hud.hunger[name])
 			 local hp = player:get_hp()
 			 if HUD_ENABLE_HUNGER and timer > 4 then
@@ -304,7 +304,7 @@ minetest.after(2.5, function()
 				if h > 15 and hp > 0 and hud.air[name] > 0 then
 					player:set_hp(hp+1)
 				-- or damage player by 1 hp if saturation is < 2 (of 30)
-				elseif h <= 1 and minetest.settings.get_bool("enable_damage") then
+				elseif h <= 1 and minetest.settings:get_bool("enable_damage") then
 					if hp-1 >= 0 then player:set_hp(hp-1) end
 				end
 			 end
@@ -321,7 +321,7 @@ minetest.after(2.5, function()
 
 			 -- update all hud elements
 			 update_hud(player)
-			
+
 			 if HUD_ENABLE_HUNGER then
 				local controls = player:get_player_control()
 				-- Determine if the player is walking
@@ -331,7 +331,7 @@ minetest.after(2.5, function()
 			 end
 			end
 		 end
-		
+
 		end
 		if timer > 4 then timer = 0 end
 		if timer2 > HUD_HUNGER_TICK then timer2 = 0 end

--- a/mods/tnt/init.lua
+++ b/mods/tnt/init.lua
@@ -1,7 +1,7 @@
 
 --[[ Default to enabled in singleplayer and disabled in multiplayer
 local singleplayer = minetest.is_singleplayer()
-local setting = minetest.settings.get_bool("enable_tnt")
+local setting = minetest.settings:get_bool("enable_tnt")
 if (not singleplayer and setting ~= true) or
 		(singleplayer and setting == false) then
 	return
@@ -13,7 +13,7 @@ local loss_prob = {}
 loss_prob["default:cobble"] = 3
 loss_prob["default:dirt"] = 4
 
-local radius = tonumber(minetest.settings.get("tnt_radius") or 3)
+local radius = tonumber(minetest.settings:get("tnt_radius") or 3)
 
 -- Fill a list with data for content IDs, after all nodes are registered
 local cid_data = {}
@@ -295,7 +295,7 @@ minetest.register_node("tnt:gunpowder", {
 	},
 	groups = {dig_immediate=2,attached_node=1,connect_to_raillike=minetest.raillike_group("gunpowder")},
 	sounds = default.node_sound_leaves_defaults(),
-	
+
 	on_punch = function(pos, node, puncher)
 		if puncher:get_wielded_item():get_name() == "default:torch" then
 			burn(pos)

--- a/mods/tnt/irc/config.lua
+++ b/mods/tnt/irc/config.lua
@@ -7,11 +7,11 @@ irc.config = {}
 local function setting(stype, name, default, required)
 	local value
 	if stype == "bool" then
-		value = minetest.settings.get_bool("irc."..name)
+		value = minetest.settings:get_bool("irc."..name)
 	elseif stype == "string" then
-		value = minetest.settings.get("irc."..name)
+		value = minetest.settings:get("irc."..name)
 	elseif stype == "number" then
-		value = tonumber(minetest.settings.get("irc."..name))
+		value = tonumber(minetest.settings:get("irc."..name))
 	end
 	if value == nil then
 		if required then
@@ -49,4 +49,3 @@ setting("bool",   "debug", false) -- Enable debug output
 setting("bool",   "enable_player_part", true) -- Whether to enable players joining and parting the channel
 setting("bool",   "auto_join", true) -- Whether to automatically show players in the channel when they join
 setting("bool",   "auto_connect", true) -- Whether to automatically connect to the server on mod load
-

--- a/mods/utils/init.lua
+++ b/mods/utils/init.lua
@@ -66,4 +66,3 @@ dofile(base_path .. "/tango.lua")
 dofile(base_path .. "/textureutil.lua")
 dofile(base_path .. "/transform.lua")
 dofile(base_path .. "/wallmountedutil.lua")
-

--- a/mods/utils/settings.lua
+++ b/mods/utils/settings.lua
@@ -42,12 +42,12 @@ settings = {}
 -- @return The value from the configuration with the given name. If the read
 --         value is nil, the default value is returned or nil.
 function settings.get(name, default_value, cast_function)
-	local value = minetest.settings.get(name)
-	
+	local value = minetest.settings:get(name)
+
 	if value ~= nil and cast_function ~= nil then
 		value = cast_function(value)
 	end
-	
+
 	if value ~= nil then
 		return value
 	else
@@ -63,8 +63,8 @@ end
 -- @return The boolean with the given name, or the default value if it is nil,
 --         or nil.
 function settings.get_bool(name, default_value)
-	local value = minetest.settings.get_bool(name)
-	
+	local value = minetest.settings:get_bool(name)
+
 	if value ~= nil then
 		return value
 	else
@@ -81,7 +81,7 @@ end
 --        or nil.
 function settings.get_list(name, default_value)
 	local value = settings.get(name, nil, tostring)
-	
+
 	if value ~= nil then
 		return stringutil.split(value, ",")
 	elseif type(default_value) == "string" then
@@ -110,15 +110,15 @@ end
 -- @return The pos with the given name, or the default value if it is nil,
 --         or nil.
 function settings.get_pos2d(name, default_value)
-	local value = minetest.settings.get(name)
-	
+	local value = minetest.settings:get(name)
+
 	if value ~= nil then
 		local splitted_value = stringutil.split(value, ",")
-		
+
 		if splitted_value:size() == 2 then
 			local x = tonumber(splitted_value:get(1))
 			local y = tonumber(splitted_value:get(2))
-			
+
 			if x ~= nil and y ~= nil then
 				return {
 					x = x,
@@ -127,7 +127,7 @@ function settings.get_pos2d(name, default_value)
 			end
 		end
 	end
-	
+
 	return default_value
 end
 
@@ -140,7 +140,7 @@ end
 --         or nil.
 function settings.get_pos3d(name, default_value)
 	local value = minetest.setting_get_pos(name)
-	
+
 	if value ~= nil then
 		return value
 	else
@@ -169,22 +169,22 @@ end
 --         value it is nil.
 function settings.get_table(name, default_value, ...)
 	local value = settings.get_list(name, nil)
-	
+
 	if value ~= nil then
 		local table = {}
-		
+
 		if ... ~= nil then
 			for index, key in ipairs({...}) do
 				table[key] = value:get(index)
 			end
 		end
-		
+
 		if ... == nil or  #{...} < value:size() then
 			for index = #{...} + 1, value:size(), 1 do
 				table[index] = value:get(index)
 			end
 		end
-		
+
 		return table
 	else
 		return default_value
@@ -193,7 +193,7 @@ end
 
 --- Saves all settings to configuration file.
 function settings.save()
-	minetest.settings.write()
+	minetest.settings:write()
 end
 
 --- Set a value with the given name into the configuration.
@@ -201,7 +201,7 @@ end
 -- @param name The name of the value to set. Is not allowed to contain '="#{}'.
 -- @param value The value.
 function settings.set(name, value)
-	minetest.settings.set(name, value)
+	minetest.settings:set(name, value)
 end
 
 --- Gets a pos from the configuration, this is an alias for get_pos3d.
@@ -212,4 +212,3 @@ end
 -- @return The pos with the given name, or the default value if it is nil,
 --         or nil.
 settings.get_pos = settings.get_pos3d
-

--- a/mods/whinny/api.lua
+++ b/mods/whinny/api.lua
@@ -162,7 +162,7 @@ function whinny:register_mob(name, def)
 
                 on_step = function(self, dtime)
 
-                        if self.type == "monster" and minetest.settings.get_bool("only_peaceful_whinny") then
+                        if self.type == "monster" and minetest.settings:get_bool("only_peaceful_whinny") then
                                 self.object:remove()
                         end
 
@@ -276,7 +276,7 @@ function whinny:register_mob(name, def)
                         end
 
                         -- FIND SOMEONE TO ATTACK
-                        if ( self.type == "monster" or self.type == "barbarian" ) and minetest.settings.get_bool("enable_damage") and self.state ~= "attack" then
+                        if ( self.type == "monster" or self.type == "barbarian" ) and minetest.settings:get_bool("enable_damage") and self.state ~= "attack" then
                                 local s = self.object:getpos()
                                 local inradius = minetest.get_objects_inside_radius(s,self.view_range)
                                 local player = nil
@@ -583,7 +583,7 @@ function whinny:register_mob(name, def)
                         self.state = "stand"
                         self.object:setvelocity({x=0, y=self.object:getvelocity().y, z=0})
                         self.object:setyaw(math.random(1, 360)/180*math.pi)
-                        if self.type == "monster" and minetest.settings.get_bool("only_peaceful_whinny") then
+                        if self.type == "monster" and minetest.settings:get_bool("only_peaceful_whinny") then
                                 self.object:remove()
                         end
                         if self.type ~= "npc" then
@@ -767,7 +767,7 @@ function whinny:register_spawn(name, nodes, max_light, min_light, chance, active
                                 return
                         end
 
-                        if minetest.settings.get_bool("display_mob_spawn") then
+                        if minetest.settings:get_bool("display_mob_spawn") then
                                 minetest.chat_send_all("[whinny] Add "..name.." at "..minetest.pos_to_string(pos))
                         end
                         local mob = minetest.add_entity(pos, name)

--- a/mods/whinny/horse.lua
+++ b/mods/whinny/horse.lua
@@ -68,7 +68,7 @@ whinny:register_mob ("whinny:horse"..basename, {
         if item:get_name() == "farming:wheat" then
             minetest.add_entity (self.object:getpos(),
 "whinny:horse"..basename.."h1")
-            if not minetest.settings.get_bool("creative_mode") then
+            if not minetest.settings:get_bool("creative_mode") then
                 item:take_item()
                 clicker:set_wielded_item(item)
             end
@@ -88,7 +88,7 @@ local function register_basehorse(name, craftitem, horse)
         function craftitem.on_place(itemstack, placer, pointed_thing)
             if pointed_thing.above then
                 minetest.env:add_entity(pointed_thing.above, name)
-                if not minetest.settings.get_bool("creative_mode") then
+                if not minetest.settings:get_bool("creative_mode") then
                     itemstack:take_item()
                 end
             end
@@ -98,7 +98,7 @@ local function register_basehorse(name, craftitem, horse)
     end
 
     function horse:set_animation(type)
-        if type == self.animation_current then 
+        if type == self.animation_current then
 			return
 		end
         if type == self.animation.mode_stand then
@@ -161,7 +161,7 @@ local function register_basehorse(name, craftitem, horse)
                 self.object:setyaw(self.object:getyaw()-3*(2-math.abs(self.speed/self.max_speed))*math.pi/90 -dtime*math.pi/90)
             end
             -- jumping (only if on ground)
-			
+
 			if ctrl.jump then
 				if on_ground then
 					local v = self.object:getvelocity()

--- a/mods/xban2/init.lua
+++ b/mods/xban2/init.lua
@@ -9,9 +9,9 @@ local tempbans = { }
 local DEF_SAVE_INTERVAL = 300 -- 5 minutes
 local DEF_DB_FILENAME = minetest.get_worldpath().."/xban.db"
 
-local DB_FILENAME = minetest.settings.get("xban.db_filename")
+local DB_FILENAME = minetest.settings:get("xban.db_filename")
 local SAVE_INTERVAL = tonumber(
-  minetest.settings.get("xban.db_save_interval")) or DEF_SAVE_INTERVAL
+  minetest.settings:get("xban.db_save_interval")) or DEF_SAVE_INTERVAL
 
 if (not DB_FILENAME) or (DB_FILENAME == "") then
 	DB_FILENAME = DEF_DB_FILENAME

--- a/mods/xdecor/nodes.lua
+++ b/mods/xdecor/nodes.lua
@@ -281,7 +281,7 @@ xdecor.register("cushion", {
 
 			minetest.set_node(pos, {name="xdecor:cushion_block", param2=node.param2})
 
-			if not minetest.settings.get_bool("creative_mode") then
+			if not minetest.settings:get_bool("creative_mode") then
 				itemstack:take_item()
 			end
 			return itemstack
@@ -563,4 +563,3 @@ xdecor.register("woodframed_glass", {
 	groups = {cracky=2, oddly_breakable_by_hand=1},
 	sounds = default.node_sound_glass_defaults()
 })
-


### PR DESCRIPTION
All deprecated `minetest.setting_` were erroneously converted to `minetest.settings.` in 44c21786ae3b20f73b2134dba0add21621866a8b. This PR fixes all incorrect function calls by replacing `minetest.settings.` with `minetest.settings:`.

Tested - game loads fine and no errors are thrown.