### PR TITLE
Fix unintended replacement of syntax

### DIFF
--- a/mods/irc/config.lua
+++ b/mods/irc/config.lua
@@ -6,7 +6,7 @@ irc.config = {}
 
 local function setting(stype, name, default, required)
 	local value
-	if minetest.settings and minetest.settings:get and minetest.settings:get_bool then
+	if minetest.settings and minetest.settings.get and minetest.settings.get_bool then
 		-- The current methods for getting settings
 		if stype == "bool" then
 			value = minetest.settings:get_bool("irc."..name)


### PR DESCRIPTION
Revert to minetest.settings.get and minetest.settings.get_bool in condition check.