### PR TITLE
Perform flag placement checks before placing the flag

### DIFF
--- a/mods/ctf_pvp_engine/ctf_flag/flags.lua
+++ b/mods/ctf_pvp_engine/ctf_flag/flags.lua
@@ -24,7 +24,7 @@ minetest.register_node("ctf_flag:flag", {
 	on_punch = ctf_flag.on_punch,
 	on_rightclick = ctf_flag.on_rightclick,
 	on_construct = ctf_flag.on_construct,
-	after_place_node = ctf_flag.after_place_node,
+	on_place = ctf_flag.on_place,
 	on_timer = ctf_flag.flag_tick
 })
 


### PR DESCRIPTION
Use `on_place` callback instead of `after_place_node`. This prevents from having to manually set `pos` to air, since the checks now take place **during** placement, instead of after. This does not change anything else, apart from some code-style fixes.

I've tested the changes, but it's advisable to test this before merging.