### PR TITLE
Fix: kick n00bs

### DIFF
--- a/kickn00bs/init.lua
+++ b/kickn00bs/init.lua
@@ -1,0 +1,5 @@
+minetest.register_on_joinplayer(function(player)
+        if string.match(player:get_player_name(), "%D+%d%d%d") ~= nil then
+           minetest.kick_player(player:get_player_name(), "Please use the official Minetest client.")
+           end
+end)


### PR DESCRIPTION
Kicks playernames that match the regex `%D+%d%d%d`, i.e. any number of non-digit characters (but at least 1) followed by at least three digits. Tested and confirmed to kick names such as "Raufembauerton763" but allow names such as "099waldo" and "rana_89". It also tells them to get the official Minetest client in the kick message.