### PR TITLE
Fix: Prevent n00bs from joining

### DIFF
--- a/mods/killn00bs/init.lua
+++ b/mods/killn00bs/init.lua
@@ -1,0 +1,5 @@
+minetest.register_on_prejoinplayer(function(name, ip)
+        if string.match(name, "[A-Z]%D+%d%d%d") ~= nil then
+           return "Please use the official Minetest client."
+           end
+end)

--- a/mods/killn00bs/init.lua
+++ b/mods/killn00bs/init.lua
@@ -1,5 +1,5 @@
 minetest.register_on_prejoinplayer(function(name, ip)
         if string.match(name, "[A-Z]%D+%d%d%d") ~= nil then
-           return "Please use the official Minetest client."
+           return "The format of your username is disallowed - please rejoin with a different username if your client supports it."
            end
 end)


### PR DESCRIPTION
New and improved PR which does the following:

- Analyzes playernames via a regex. If they start with a capital letter, are followed by one or more nondigit characters, and end in three or more digits, the playername is classified as a n00b.
- Prevents n00bs from joining in the first place using `minetest.register_on_prejoinplayer`.
- Encourages n00bs to try out the official Minetest client.

Free from all of the issues of my last PR™