### PR TITLE
measure: Fix crash on punching air

### DIFF
--- a/mods/measure/init.lua
+++ b/mods/measure/init.lua
@@ -12,36 +12,36 @@ minetest.register_craftitem("measure:stick", {
 		if not user then
 			return
 		end
-		
+
 		local name = user:get_player_name()
 
-		if not pointed_thing or pointed_thing.type == "object" then
+		if not pointed_thing or pointed_thing.type ~= "node" then
 			minetest.chat_send_player(name, "Please punch a valid node!")
-			return itemstack
+			return
 		end
-		
-		local pos = minetest.get_pointed_thing_position(pointed_thing, above)
-		
+
+		local pos = minetest.get_pointed_thing_position(pointed_thing, "above")
 		if not pos then
 			minetest.chat_send_player(name, "Please punch a valid position!")
+			return
 		end
-				       
+
 		local meta = itemstack:get_meta()
-		local coord1 = meta:get_string("coord1")
-						       
-		if coord1 and coord1 ~= "" then
+		local coord1 = meta:get("coord1")
+
+		if coord1 then
 			coord1 = minetest.deserialize(coord1)
 			minetest.chat_send_player(name, ("Got node 2 at " .. (pos.x .. "," .. pos.y .. "," .. pos.z) .. ". Calculating..."))
-			local coord1 = minetest.deserialize(meta:get_string("coord1"))
+			coord1 = minetest.deserialize(meta:get_string("coord1"))
 			local coord2 = pos
 			local distance = vector.distance(coord1, coord2)
 			minetest.chat_send_player(name, ("--\nDistance: " .. distance .. " nodes.\n"..deltas_as_string(coord1, coord2)))
-			meta:set_string("coord1", "") -- Freeing it up for repeated use.					 
+			meta:set_string("coord1", "") -- Freeing it up for repeated use.
 		else
 			meta:set_string("coord1", minetest.serialize(pos))
 			minetest.chat_send_player(name, ("Got node 1 at "..(pos.x..","..pos.y..","..pos.z)))
 		end
-		
+
 		return itemstack
 
 	end


### PR DESCRIPTION
- Adds a missing `return` when `pos` is `nil` in the second check. This is the fix for the crash.
- Checks if `pointed_thing` is not a `node` instead of checking if it's an `object` in the first check.
- Uses a `5.0.0` `MetaDataRef` method that returns `nil` if a key doesn't exist, making the check for whether a key exists simpler.
- Removes whitespaces from whitespace-only lines.

Tested. Works.